### PR TITLE
Fix field definition type field

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -231,7 +231,7 @@ Definition for a field in a complex data type.
 
 Field Name | Type | Description
 ---|:---:|---
-<a name="fieldType"></a>field | `string` | **REQUIRED**. The name of the type of the field. It MUST be a type name that exists within the Conjure definition.
+<a name="fieldType"></a>type | `string` | **REQUIRED**. The name of the type of the field. It MUST be a type name that exists within the Conjure definition.
 <a name="fieldDocs"></a>docs | `string` | Documentation for the type. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 
 


### PR DESCRIPTION
Our README example suggests the `type` sub-field of a `field` definition should be called `type`, not `field`.