### PR TITLE
Date -> rfc 3339, double -> only finite

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -63,7 +63,7 @@ bearertoken | `string`  |
 binary      | `string`  | // TODO
 boolean     | `boolean` |
 datetime    | `datetime` | As defined by [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) but without localized timestamps like `2017-01-02T04:04:05.000000000+01:00[Europe/Berlin]`. Only UTC is supported.
-double      | `number`  | As defined by [IEEE 754 standard](http://ieeexplore.ieee.org/document/4610935/), except `NaN`.
+double      | `number`  | As defined by [IEEE 754 standard](http://ieeexplore.ieee.org/document/4610935/), but only supporting finite values (`NaN` / `∞` / `-∞` are not supported).
 integer     | `integer` | Signed 32 bits, value ranging from -2<sup>31</sup> to 2<sup>31</sup> - 1.
 rid         | `string`  | In accordance with the [Resource Identifer](https://github.com/palantir/resource-identifier) definition.
 safelong    | `integer` | Integer with value ranging from -2<sup>53</sup> - 1 to 2<sup>53</sup> - 1.


### PR DESCRIPTION
Narrow down formats:

DateTime: [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) without localized timestamps like `2017-01-02T04:04:05.000000000+01:00[Europe/Berlin]`.

Double: as before but not allowing NaN / infinity / negative infinity.
