### PR TITLE
illegal nested optionals

### DIFF
--- a/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureTypeParserVisitor.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureTypeParserVisitor.java
@@ -35,6 +35,7 @@ import com.palantir.conjure.parser.types.reference.LocalReferenceType;
 import com.palantir.conjure.spec.ExternalReference;
 import com.palantir.conjure.spec.Type;
 import com.palantir.conjure.spec.TypeName;
+import com.palantir.conjure.visitor.TypeVisitor;
 import java.util.Optional;
 
 /** The core translator between parsed/raw types and the IR spec representation exposed to compilers. */
@@ -127,7 +128,10 @@ public final class ConjureTypeParserVisitor implements ConjureTypeVisitor<Type> 
 
     @Override
     public Type visitOptional(OptionalType type) {
-        return Type.optional(com.palantir.conjure.spec.OptionalType.of(type.itemType().visit(this)));
+        com.palantir.conjure.spec.OptionalType innerType = com.palantir.conjure.spec.OptionalType.of(
+                type.itemType().visit(this));
+        Preconditions.checkState(!innerType.getItemType().accept(TypeVisitor.IS_OPTIONAL), "Illegal nested optionals");
+        return Type.optional(innerType);
     }
 
     @Override

--- a/conjure-core/src/test/resources/spec-tests/objects.yml
+++ b/conjure-core/src/test/resources/spec-tests/objects.yml
@@ -55,3 +55,14 @@ negative:
                 other: Other
             Other:
               alias: One
+
+  nestedOptionals:
+    expected-error: 'Illegal nested optionals'
+    conjure:
+      types:
+        definitions:
+          default-package: test.api
+          objects:
+            One:
+              fields:
+                other: optional<optional<string>>


### PR DESCRIPTION
Disallow nested optionals. Technically this is a break, but it shouldn't impact anyones wire API so it should be fine