### PR TITLE
update python link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -161,7 +161,7 @@ Code generators
 
 - [conjure-java](https://github.com/palantir/conjure-java)
 - [conjure-typescript](https://github.com/palantir/conjure-typescript)
-- conjure-python (coming)
+- [conjure-python](https://github.com/palantir/conjure-python)
 - conjure-go (coming soon)
 - conjure-rust (coming soon)
 


### PR DESCRIPTION
## Before this PR
`conjure-python` repo wasn't linked
## After this PR
A link to `conjure-python` repo is provided.