### PR TITLE
[fix] Generate node compatible api

### DIFF
--- a/conjure-api/build.gradle
+++ b/conjure-api/build.gradle
@@ -30,3 +30,9 @@ project (':conjure-api:conjure-api-typescript') {
         file('src/.npmrc') << "//registry.npmjs.org/:_authToken=${System.env.NPM_AUTH_TOKEN}"
     }
 }
+
+conjure {
+    typescript {
+        nodeCompatibleModules = true
+    }
+}


### PR DESCRIPTION
Generate nodeCompatible modules to enable `conjure-typescript` usage