### PR TITLE
[fix] do not allow null values for required object type fields

### DIFF
--- a/conjure-core/src/main/java/com/palantir/conjure/parser/types/complex/EnumTypeDefinition.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/types/complex/EnumTypeDefinition.java
@@ -16,6 +16,8 @@
 
 package com.palantir.conjure.parser.types.complex;
 
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.TreeNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -31,6 +33,7 @@ import org.immutables.value.Value;
 @ConjureImmutablesStyle
 public interface EnumTypeDefinition extends BaseObjectTypeDefinition {
 
+    @JsonSetter(nulls = Nulls.FAIL, contentNulls = Nulls.FAIL)
     List<EnumValueDefinition> values();
 
     @Override
@@ -39,9 +42,6 @@ public interface EnumTypeDefinition extends BaseObjectTypeDefinition {
     }
 
     static EnumTypeDefinition fromJson(JsonParser parser, TreeNode json) throws IOException {
-        if (!json.get("values").isArray()) {
-            throw new IllegalArgumentException("Property 'values' must contain a list.");
-        }
         return parser.getCodec().treeToValue(json, EnumTypeDefinition.class);
     }
 

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/types/complex/ObjectTypeDefinition.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/types/complex/ObjectTypeDefinition.java
@@ -16,6 +16,8 @@
 
 package com.palantir.conjure.parser.types.complex;
 
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.TreeNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -32,6 +34,7 @@ import org.immutables.value.Value;
 @ConjureImmutablesStyle
 public interface ObjectTypeDefinition extends BaseObjectTypeDefinition {
 
+    @JsonSetter(nulls = Nulls.FAIL, contentNulls = Nulls.FAIL)
     Map<FieldName, FieldDefinition> fields();
 
     @Override
@@ -40,9 +43,6 @@ public interface ObjectTypeDefinition extends BaseObjectTypeDefinition {
     }
 
     static ObjectTypeDefinition fromJson(JsonParser parser, TreeNode json) throws IOException {
-        if (!json.get("fields").isObject()) {
-            throw new IllegalArgumentException("Property 'fields' must contain a map.");
-        }
         return parser.getCodec().treeToValue(json, ImmutableObjectTypeDefinition.class);
     }
 

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/types/complex/UnionTypeDefinition.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/types/complex/UnionTypeDefinition.java
@@ -16,6 +16,8 @@
 
 package com.palantir.conjure.parser.types.complex;
 
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.TreeNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -32,6 +34,7 @@ import org.immutables.value.Value;
 @ConjureImmutablesStyle
 public interface UnionTypeDefinition extends BaseObjectTypeDefinition {
 
+    @JsonSetter(nulls = Nulls.FAIL, contentNulls = Nulls.FAIL)
     Map<FieldName, FieldDefinition> union();
 
     @Override
@@ -40,9 +43,6 @@ public interface UnionTypeDefinition extends BaseObjectTypeDefinition {
     }
 
     static UnionTypeDefinition fromJson(JsonParser parser, TreeNode json) throws IOException {
-        if (!json.get("union").isObject()) {
-            throw new IllegalArgumentException("Property 'union' must contain a map.");
-        }
         return parser.getCodec().treeToValue(json, UnionTypeDefinition.class);
     }
 

--- a/conjure-core/src/test/java/com/palantir/conjure/parser/KebabCaseEnforcingAnnotationInspectorTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/parser/KebabCaseEnforcingAnnotationInspectorTest.java
@@ -20,8 +20,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
 import org.junit.Test;
 
 public final class KebabCaseEnforcingAnnotationInspectorTest {
@@ -56,9 +56,9 @@ public final class KebabCaseEnforcingAnnotationInspectorTest {
     @Test
     public void testSetterWithoutAnnotationIsInvalid() throws Exception {
         assertThatThrownBy(() -> mapper.readValue("{\"fooBar\": \"baz\"}", NoAnnotationInvalidTarget.class))
-                .isInstanceOf(JsonMappingException.class)
-                .hasCause(new IllegalArgumentException("All setter ({@code set*}) deserialization targets require "
-                        + "@JsonProperty annotations: setFooBar"));
+                .isInstanceOf(InvalidDefinitionException.class)
+                .hasMessageContaining("All setter ({@code set*}) deserialization targets require "
+                        + "@JsonProperty annotations: setFooBar");
     }
 
     private static class NonKebabCaseAnnotationInvalidTarget {
@@ -73,7 +73,7 @@ public final class KebabCaseEnforcingAnnotationInspectorTest {
     @Test
     public void testSetterWithNonKebabCaseAnnotationIsInvalid() throws Exception {
         assertThatThrownBy(() -> mapper.readValue("{\"fooBar\": \"baz\"}", NonKebabCaseAnnotationInvalidTarget.class))
-                .isInstanceOf(JsonMappingException.class)
-                .hasCause(new IllegalArgumentException("Conjure grammar requires kebab-case field names: fooBar"));
+                .isInstanceOf(InvalidDefinitionException.class)
+                .hasMessageContaining("Conjure grammar requires kebab-case field names: fooBar");
     }
 }

--- a/conjure-core/src/test/java/com/palantir/conjure/parser/services/ServiceDefinitionTests.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/parser/services/ServiceDefinitionTests.java
@@ -120,7 +120,7 @@ public final class ServiceDefinitionTests {
     public void testParseEnum_blank() {
         assertThatThrownBy(() -> mapper.readValue(multiLineString(
                 "values:"), BaseObjectTypeDefinition.class))
-                .hasMessageContaining("Property 'values' must contain a list");
+                .hasMessageContaining("Invalid `null` value encountered for property \"values\"");
 
     }
 
@@ -135,7 +135,7 @@ public final class ServiceDefinitionTests {
     public void testParseEnum_null() {
         assertThatThrownBy(() -> mapper.readValue(multiLineString(
                 "values: null"), BaseObjectTypeDefinition.class))
-                .hasMessageContaining("Property 'values' must contain a list");
+                .hasMessageContaining("Invalid `null` value encountered for property \"values\"");
     }
 
     @Test
@@ -171,7 +171,7 @@ public final class ServiceDefinitionTests {
     public void testParseUnion_blank() {
         assertThatThrownBy(() -> mapper.readValue(multiLineString(
                 "union:"), BaseObjectTypeDefinition.class))
-                .hasMessageContaining("Property 'union' must contain a map");
+                .hasMessageContaining("Invalid `null` value encountered for property \"union\"");
     }
 
     @Test
@@ -185,7 +185,7 @@ public final class ServiceDefinitionTests {
     public void testParseUnion_null() {
         assertThatThrownBy(() -> mapper.readValue(multiLineString(
                 "union: null"), BaseObjectTypeDefinition.class))
-                .hasMessageContaining("Property 'union' must contain a map");
+                .hasMessageContaining("Invalid `null` value encountered for property \"union\"");
     }
 
     @Test
@@ -206,7 +206,7 @@ public final class ServiceDefinitionTests {
     public void testParseType_blank() {
         assertThatThrownBy(() -> mapper.readValue(multiLineString(
                 "fields:"), BaseObjectTypeDefinition.class))
-                .hasMessageContaining("Property 'fields' must contain a map");
+                .hasMessageContaining("Invalid `null` value encountered for property \"fields\"");
     }
 
     @Test
@@ -220,7 +220,7 @@ public final class ServiceDefinitionTests {
     public void testParseType_null() {
         assertThatThrownBy(() -> mapper.readValue(multiLineString(
                 "fields:"), BaseObjectTypeDefinition.class))
-                .hasMessageContaining("Property 'fields' must contain a map");
+                .hasMessageContaining("Invalid `null` value encountered for property \"fields\"");
     }
 
     @Test

--- a/conjure/src/test/java/com/palantir/conjure/cli/ConjureCliTest.java
+++ b/conjure/src/test/java/com/palantir/conjure/cli/ConjureCliTest.java
@@ -111,6 +111,6 @@ public final class ConjureCliTest {
                 .build();
         assertThatThrownBy(() -> ConjureCli.generate(configuration))
                 .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("JsonMappingException");
+                .hasMessageContaining("MismatchedInputException");
     }
 }

--- a/versions.props
+++ b/versions.props
@@ -1,4 +1,4 @@
-com.fasterxml.jackson.*:jackson-* = 2.7.4
+com.fasterxml.jackson.*:jackson-* = 2.9.6
 com.fasterxml.jackson.datatype:jackson-datatype-jdk7 = 2.6.7
 com.google.code.findbugs:jsr305 = 3.0.2
 com.google.errorprone:error_prone_annotations = 2.3.1


### PR DESCRIPTION
## Before this PR
See #82. This matters to me because an internal tool was choking on this undefined behavior.

## After this PR
Fixes #82.