### PR TITLE
[fix] Spec: unify request/response content-type for JSON

### DIFF
--- a/docs/spec/wire.md
+++ b/docs/spec/wire.md
@@ -79,7 +79,7 @@ It is RECOMMENDED to add a `Content-Length` header for [compatibility](https://t
 
 1. **Headers** - Conjure `header` parameters MUST be serialized in the [PLAIN format][] and transferred as [HTTP Headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers). Header names are case insensitive. Parameters of Conjure type `optional<T>` MUST be omitted entirely if the value is not present, otherwise just serialized using the [PLAIN Format][].
 
-1. **Content-Type header** - For Conjure endpoints that define a `body` argument, a `Content-Type` header MUST be added.  If the body is of type `binary`, the content-type `application/octet-stream` MUST be used. Otherwise, clients MUST send `Content-Type: application/json`. Note that the default encoding for `application/json` content type is [`UTF-8`](http://www.ietf.org/rfc/rfc4627.txt#3).
+1. **Content-Type header** - For Conjure endpoints that define a `body` argument, a `Content-Type` header MUST be added.  If the body is of type `binary`, the content-type `application/octet-stream` MUST be used. Otherwise, clients MUST send `Content-Type: application/json`. Note that the default encoding for `application/json` content type is [`UTF-8`](http://www.ietf.org/rfc/rfc4627.txt).
 
 1. **Accept header** - Clients MUST send an `Accept: application/json` header for all requests UNLESS the endpoint returns binary, in which case the client MUST send `Accept: application/octet-stream`. This ensures changes can be made to the wire format in a non-breaking way.
 


### PR DESCRIPTION
Fixes https://github.com/palantir/conjure/issues/75
## Before this PR
There are inconsistent content types specified in the Conjure Wire Spec for request and response.
For HTTP Request, if the body is not type binaray, the spec requires clients to send `Content-Type: application/json`.
For HTTP Response, if the return type is not binary, the spec requires server to respond with  `Content-Type: application/json;charset=utf-8`.

## After this PR
Spec requires both client and server to add `Content-Type: application/json` header without `charset=utf-8` encoding in request and response, respectively. Since `charset=utf-8` is the default encoding for `application/json` content type according to http://www.ietf.org/rfc/rfc4627.txt, there is no need to explicitly specify it. 