### PR TITLE
[fix] Resolve imported types

### DIFF
--- a/conjure-core/src/test/java/com/palantir/conjure/defs/ConjureDefTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/ConjureDefTest.java
@@ -1,0 +1,44 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.defs;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableList;
+import com.palantir.conjure.parser.ConjureParser;
+import com.palantir.conjure.spec.ConjureDefinition;
+import java.io.File;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class ConjureDefTest {
+
+    @Test
+    public void resolvesImportedAliases() {
+        ConjureDefinition conjureDefinition = ConjureParserUtils.parseConjureDef(
+                ImmutableList.of(ConjureParser.parse(new File("src/test/resources/example-conjure-imports.yml"))));
+        assertEquals(conjureDefinition.getTypes().size(), 1);
+    }
+
+    // Test currently fails as it attempts to parse a TypeScript package name as a java package
+    @Test
+    @Ignore
+    public void handlesNonJavaExternalType() {
+        ConjureDefinition conjureDefinition = ConjureParserUtils.parseConjureDef(
+                ImmutableList.of(ConjureParser.parse(new File("src/test/resources/example-external-types.yml"))));
+    }
+}

--- a/conjure-core/src/test/resources/example-conjure-imports.yml
+++ b/conjure-core/src/test/resources/example-conjure-imports.yml
@@ -7,7 +7,7 @@ types:
       ComplexObjectWithImports:
         fields:
           string: string
-          imports: imported.SimpleObject
+          imports: imports.SimpleObject
 
 services:
   TestService:
@@ -19,3 +19,8 @@ services:
         http: POST /testEndpoint
         args:
           importedString: imports.SimpleObject
+
+      testImportEndpoint:
+        http: POST /testImport/{name}
+        args:
+          name: imports.StringAlias

--- a/conjure-core/src/test/resources/example-external-types.yml
+++ b/conjure-core/src/test/resources/example-external-types.yml
@@ -12,3 +12,13 @@ types:
       base-type: string
       external:
         typescript: "@palantir/foo"
+
+  # Required otherwise imports are ignored by the compiler
+  definitions:
+    default-package: test.api.with.external.types
+    objects:
+      ComplexObjectWithImports:
+        fields:
+          anyImport: ExampleAnyImport
+          integerImport:  ExampleIntegerImport
+          typescriptImport: ExampleTypeScriptImport


### PR DESCRIPTION
Closes #95 
## Before this PR
We were only able to resolve types that were defined the the current scope. This lead to issues when trying to determine whether a type was a valid alias of primitive

## After this PR
We now can now resolve any type in the current scope or its recursive set of imported scopes. The implementation is pretty janky, but I think a better solution would involve a more elaborate rewrite.

Also for kicks we now actually try to compile the examples in the repo