### PR TITLE
[fix] Fix #98: External type imports are dealiased properly

### DIFF
--- a/conjure-core/src/test/resources/spec-tests/services.yml
+++ b/conjure-core/src/test/resources/spec-tests/services.yml
@@ -117,6 +117,44 @@ positive:
                   type: Alias1
                   param-type: header
                   param-id: Bar
+  allowImportAsQueryParam:
+    conjure:
+      types:
+        imports:
+          Long:
+            base-type: string
+            external:
+              java: java.lang.Long
+      services:
+        Unused:
+          name: Unused
+          package: unused
+          endpoints:
+            unused:
+              http: GET /foo
+              args:
+                bar:
+                  type: Long
+                  param-type: query
+  allowImportAsPathParam:
+    conjure:
+      types:
+        imports:
+          Long:
+            base-type: string
+            external:
+              java: java.lang.Long
+      services:
+        Unused:
+          name: Unused
+          package: unused
+          endpoints:
+            unused:
+              http: GET /foo/{baz}
+              args:
+                baz:
+                  type: Long
+                  param-type: path
 
 negative:
   disallowBearerTokenInPathParams:

--- a/conjure-generator-common/src/main/java/com/palantir/conjure/visitor/DealiasingTypeVisitor.java
+++ b/conjure-generator-common/src/main/java/com/palantir/conjure/visitor/DealiasingTypeVisitor.java
@@ -116,7 +116,7 @@ public final class DealiasingTypeVisitor implements Type.Visitor<Either<TypeDefi
 
     @Override
     public Either<TypeDefinition, Type> visitExternal(ExternalReference value) {
-        return Either.right(Type.external(value));
+        return dealias(value.getFallback());
     }
 
     @Override


### PR DESCRIPTION
[fix] Fix #98: External type imports are dealiased properly

## Before this PR
Existing conjure definitions fail to parse due failure to interpret external type imports as their primitive base types.

## After this PR
Conjure upgrade unblocked for now
