### PR TITLE
[fix] When an external import base-type is not defined, 'any' is assumed

### DIFF
--- a/conjure-core/src/main/java/com/palantir/conjure/parser/types/reference/ExternalTypeDefinition.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/types/reference/ExternalTypeDefinition.java
@@ -33,11 +33,14 @@ public interface ExternalTypeDefinition {
     @JsonProperty("base-type")
     @Value.Default
     default PrimitiveType baseType() {
-        return PrimitiveType.STRING;
+        return PrimitiveType.ANY;
     }
 
-    static ExternalTypeDefinition javaType(String external) {
-        return ImmutableExternalTypeDefinition.builder().putExternal("java", external).build();
+    static ExternalTypeDefinition javaType(String external, PrimitiveType baseType) {
+        return ImmutableExternalTypeDefinition.builder()
+                .putExternal("java", external)
+                .baseType(baseType)
+                .build();
     }
 
 }

--- a/conjure-core/src/test/java/com/palantir/conjure/parser/services/ServiceDefinitionTests.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/parser/services/ServiceDefinitionTests.java
@@ -263,7 +263,8 @@ public final class ServiceDefinitionTests {
                 ConjureSourceFile.builder()
                         .types(TypesDefinition.builder()
                                 .putImports(TypeName.of("ResourceIdentifier"),
-                                        ExternalTypeDefinition.javaType("com.palantir.ri.ResourceIdentifier"))
+                                        ExternalTypeDefinition.javaType(
+                                                "com.palantir.ri.ResourceIdentifier", PrimitiveType.STRING))
                                 .definitions(NamedTypesDefinition.builder()
                                         .defaultConjurePackage(ConjurePackage.of("test.api"))
                                         .putObjects(TypeName.of("SimpleObject"), ObjectTypeDefinition.builder()


### PR DESCRIPTION
This was previously the default value. 'Any' is much safer to
assume because the external type is an unknown.

## Before this PR
External type imports were assumed to have `base-type` of `string` unless otherwise specified, which is dangerous to assume.

## After this PR
`base-type` default value is `any`, making it less likely that we produce data that fails to parse on non-java clients.
