### PR TITLE
[fix] Fix optional external types.

### DIFF
--- a/conjure-core/src/test/resources/spec-tests/services.yml
+++ b/conjure-core/src/test/resources/spec-tests/services.yml
@@ -155,6 +155,25 @@ positive:
                 baz:
                   type: Long
                   param-type: path
+  allowOptionalImportAsQueryParam:
+    conjure:
+      types:
+        imports:
+          Long:
+            base-type: string
+            external:
+              java: optional<java.lang.Long>
+      services:
+        Unused:
+          name: Unused
+          package: unused
+          endpoints:
+            unused:
+              http: GET /fee/foo
+              args:
+                bar:
+                  type: Long
+                  param-type: query
 
 negative:
   disallowBearerTokenInPathParams:

--- a/conjure-generator-common/src/main/java/com/palantir/conjure/visitor/DealiasingTypeVisitor.java
+++ b/conjure-generator-common/src/main/java/com/palantir/conjure/visitor/DealiasingTypeVisitor.java
@@ -87,16 +87,26 @@ public final class DealiasingTypeVisitor implements Type.Visitor<Either<TypeDefi
         });
     }
 
+    @Override
+    public Either<TypeDefinition, Type> visitExternal(ExternalReference value) {
+        return dealias(value.getFallback());
+    }
+
+    @Override
+    public Either<TypeDefinition, Type> visitOptional(OptionalType value) {
+        Either<TypeDefinition, Type> innerType = value.getItemType().accept(this);
+        return Either.right(innerType.fold(
+                typeDefinition -> {
+                    throw new IllegalStateException("cannot be an optional of type definition");
+                },
+                type -> Type.optional(OptionalType.of(type))));
+    }
+
     // Identity mapping for here onwards.
 
     @Override
     public Either<TypeDefinition, Type> visitPrimitive(PrimitiveType value) {
         return Either.right(Type.primitive(value));
-    }
-
-    @Override
-    public Either<TypeDefinition, Type> visitOptional(OptionalType value) {
-        return Either.right(Type.optional(value));
     }
 
     @Override
@@ -112,11 +122,6 @@ public final class DealiasingTypeVisitor implements Type.Visitor<Either<TypeDefi
     @Override
     public Either<TypeDefinition, Type> visitMap(MapType value) {
         return Either.right(Type.map(value));
-    }
-
-    @Override
-    public Either<TypeDefinition, Type> visitExternal(ExternalReference value) {
-        return dealias(value.getFallback());
     }
 
     @Override


### PR DESCRIPTION
## Before this PR
See: https://github.com/palantir/conjure/issues/105, we are unable to move to OSS conjure in applications that use Optional<ExternalTypes> in headers or path params.

## After this PR
Optionals are dealiased correctly.