### PR TITLE
Rich github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,17 @@
+---
+name: 🐛 Bug report
+about: Something not working as expected?
+---
+
+## What happened?
+
+<!--
+Describe what you've observed and why it's bad (please include whatever stacktraces/version numbers you can).
+Clear steps to reproduce the behaviour are always helpful too!
+-->
+
+## What did you want to happen?
+
+<!--
+Suggest better behaviour
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: ⭐️ Feature request
+about: Propose a new feature or suggest an idea
+---
+
+## Motivation
+
+<!--
+Describe what you're trying to do. (Please include whatever version numbers or links you can).
+-->
+
+## Proposal
+
+<!--
+Suggest something better, with examples if possible!
+-->

--- a/.github/ISSUE_TEMPLATE/support_question.md
+++ b/.github/ISSUE_TEMPLATE/support_question.md
@@ -1,0 +1,12 @@
+---
+name: 🙋‍ How do I...
+about: Need help with Conjure?
+---
+
+<!--
+
+We recommend asking questions on https://stackoverflow.com/questions/tagged/conjure so people can upvote the most helpful answers!
+
+Alternatively, feel free to email the Google Group:  https://groups.google.com/forum/#!forum/palantir-conjure
+
+-->


### PR DESCRIPTION
_Github supports [rich templates](https://blog.github.com/2018-05-02-issue-template-improvements/) now, let's use them._

## Before this PR

Anyone filing an issue on this repo is faced with an empty box to fill.  This makes it harder for contributors to write really high quality github issues first time (as it's not clear what information maintainers are most interested in).

<img width="1057" alt="screen shot 2018-10-18 at 16 21 29" src="https://user-images.githubusercontent.com/3473798/47165510-06096e00-d2f2-11e8-9a92-735e6d042322.png">

## After this PR

Clicking the "New Issue" button will result in a slick three-choice screen, just like Blueprint (https://github.com/palantir/blueprint/pull/2469):

<img width="818" alt="screen shot 2018-10-18 at 16 23 48" src="https://user-images.githubusercontent.com/3473798/47165602-39e49380-d2f2-11e8-9dbc-644838675d12.png">

I hope this will provide a welcoming landing pad for contributors and minimize round-trip questions from maintainers.
