### PR TITLE
Cleanup wire specification

### DIFF
--- a/docs/spec/wire.md
+++ b/docs/spec/wire.md
@@ -286,7 +286,7 @@ _Enum_            | unquoted variant name                         | UTF-8 string
 
 ## Canonical JSON Format
 
-The Canonical JSON format is a constrained version of the [JSON format][] which disambiguates values for 
+The Canonical JSON format is a constrained version of the [JSON format][] that disambiguates values for 
 types which have multiple distinct representations that are conceptually equivalent. 
 Implementations of Conjure clients/servers must convert types (even if implicitly) from their JSON/Plain format to 
 their canonical form when determining equality.


### PR DESCRIPTION
Addresses some outstanding issues with the wire specification.
In particular:
- Removes RFC2119
- Disambiguates binary format
- Addresses issues with serialization of any and maps
- clarifies that "Canonical JSON format" is a subset of "JSON format"
- clarifies that "PLAIN format" is derived from JSON-formatted values, reiterating comments from "JSON format" on the expected format by conjure type

[Rendered link](https://github.com/palantir/conjure/blob/fo/wire-fix/docs/spec/wire.md)