### PR TITLE
[docs] update docs to note that uuid isn't a number

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -36,7 +36,7 @@ Users may define the following kinds of named types. These can be referenced by 
   - `rid` - a [Resource Identifier](https://github.com/palantir/resource-identifier), e.g. `ri.recipes.main.ingredient.1234`
   - `safelong` - a signed 53-bit integer that can be safely represented by browsers without loss of precision, value ranges from -2<sup>53</sup> + 1 to 2<sup>53</sup> - 1
   - `string` - a sequence of UTF-8 characters
-  - `uuid` - a 128-bit number: [Universally Unique Identifier](https://en.wikipedia.org/wiki/Universally_unique_identifier#Versions) (aka guid)
+  - `uuid` - [Universally Unique Identifier](https://en.wikipedia.org/wiki/Universally_unique_identifier#Versions) (aka guid) represented as a string
 
 ### Opaque types
 When migrating an existing API, it may be useful to use the following 'escape hatch' type.  These are not recommended for normal APIs because Conjure can't introspect these external types to figure out what their JSON structure will be, so they're effectively opaque.


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
It implies that guids are numbers where they are really strings

## After this PR
It clarifies they are strings.

