### PR TITLE
docs: Correct link to conjure-python-client

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,7 @@ _Conjure generators_ read IR and produce code in the target language. The associ
 |--------------------|-------------------------------|-|-|
 | Java | [conjure-java](https://github.com/palantir/conjure-java) | [conjure-java-runtime](https://github.com/palantir/conjure-java-runtime) | [conjure-java-example](https://github.com/palantir/conjure-java-example) |
 | TypeScript | [conjure-typescript](https://github.com/palantir/conjure-typescript) | [conjure-typescript-runtime](https://github.com/palantir/conjure-typescript-runtime) | [conjure-typescript-example](https://github.com/palantir/conjure-typescript-example) |
-| Python | [conjure-python](https://github.com/palantir/conjure-python) | [conjure-python-runtime](https://github.com/palantir/conjure-python-runtime) | - |
+| Python | [conjure-python](https://github.com/palantir/conjure-python) | [conjure-python-client](https://github.com/palantir/conjure-python-client) | - |
 
 The [gradle-conjure](https://github.com/palantir/gradle-conjure) _build tool_ is the recommended way of interacting with the Conjure ecosystem as it seamlessly orchestrates all the above tools. Alternatively, the compiler and generators may also be invoked [manually](/docs/howto/invoke_clis_manually.md#how-to-invoke-conjure-clis-manually) as they all behave in a consistent way (specified by [RFC002](/docs/rfc/002-contract-for-conjure-generators.md)).
 


### PR DESCRIPTION
## Before this PR
There was a dead link to conjure-python-runtime

## After this PR
The link now points to conjure-python-client