### PR TITLE
[fix] Fix arguments spec

### DIFF
--- a/docs/spec/conjure_definitions.md
+++ b/docs/spec/conjure_definitions.md
@@ -365,6 +365,7 @@ param&#8209;type | [ArgumentDefinition.ParamType][] | The type of the endpoint p
 ## ArgumentDefinition.ParamType
 [ArgumentDefinition.ParamType]: #argumentdefinitionparamtype
 A field describing the type of an endpoint parameter. It is a `string` which MUST be one of the following:
+- `auto`: defined as the singluar body parameter or a path parameter if the name of the argument definition matches a path parameter
 - `path`: defined as a path parameter; the argument name must appear in the request line.
 - `body`: defined as the singular body parameter.
 - `header`: defined as a header parameter.

--- a/docs/spec/wire.md
+++ b/docs/spec/wire.md
@@ -87,8 +87,12 @@ For example, the following Conjure endpoint contains two query parameters:
 demoEndpoint:
   http: GET /recipes
   args:
-    filter: optional<string>
-    limit: optional<integer>
+    filter:
+      param-type: query
+      type: optional<string>
+    limit:
+      param-type: query
+      type: optional<integer>
 ```
 
 These examples illustrate how an `optional<T>` value should be omitted if the value is not present


### PR DESCRIPTION
## Before this PR
Argument definition spec did not document the default behaviour and wire spec examples were not correct.

## After this PR
The spec has been corrected
