### PR TITLE
[fix] Fix getting started build.gradle

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -29,6 +29,7 @@ In your top level `build.gradle` file, add a buildscript dependency on Conjure.
 ```groovy
 buildscript {
     repositories {
+        mavenCentral()
         maven { url 'https://dl.bintray.com/palantir/releases/' }
     }
 


### PR DESCRIPTION
## Before this PR
Users exactly following the getting started guide would be unable to resolve all their build script dependencies and would get a very confusing error.

## After this PR
Users following the getting started guide should no longer encounter any issues.

Thanks to MrFantastik from Lobster for [point this out](https://lobste.rs/s/egbgwb/introducing_conjure_palantir_s#c_vzpbkj)