### PR TITLE
[improvement] Allow dots in endpoint paths

### DIFF
--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/HttpPathValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/HttpPathValidator.java
@@ -36,7 +36,7 @@ public final class HttpPathValidator {
 
     private HttpPathValidator() {}
 
-    public static final String PATTERN = "[a-z][a-z0-9]*([A-Z0-9][a-z0-9].+)*";
+    public static final String PATTERN = "[a-z][a-z0-9]*([A-Z0-9][a-z0-9]+)*";
     private static final Pattern SEGMENT_PATTERN = Pattern.compile("^[a-zA-Z][a-zA-Z0-9._-]*$");
     private static final Pattern PARAM_SEGMENT_PATTERN = Pattern.compile("^\\{" + PATTERN + "}$");
     private static final Pattern PARAM_REGEX_SEGMENT_PATTERN =

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/HttpPathValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/HttpPathValidator.java
@@ -36,8 +36,8 @@ public final class HttpPathValidator {
 
     private HttpPathValidator() {}
 
-    public static final String PATTERN = "[a-z][a-z0-9]*([A-Z0-9][a-z0-9]+)*";
-    private static final Pattern SEGMENT_PATTERN = Pattern.compile("^[a-zA-Z][a-zA-Z0-9_-]*$");
+    public static final String PATTERN = "[a-z][a-z0-9]*([A-Z0-9][a-z0-9].+)*";
+    private static final Pattern SEGMENT_PATTERN = Pattern.compile("^[a-zA-Z][a-zA-Z0-9._-]*$");
     private static final Pattern PARAM_SEGMENT_PATTERN = Pattern.compile("^\\{" + PATTERN + "}$");
     private static final Pattern PARAM_REGEX_SEGMENT_PATTERN =
             Pattern.compile(

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/services/PathString.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/services/PathString.java
@@ -39,7 +39,7 @@ public abstract class PathString {
     /** Returns the well-formed path associated with this path definition. */
     public abstract Path path();
 
-    private static final Pattern SEGMENT_PATTERN = Pattern.compile("^[a-zA-Z][a-zA-Z0-9_-]*$");
+    private static final Pattern SEGMENT_PATTERN = Pattern.compile("^[a-zA-Z][a-zA-Z0-9._-]*$");
     private static final Pattern PARAM_SEGMENT_PATTERN = Pattern.compile("^\\{" + ParameterName.PATTERN + "}$");
     private static final Pattern PARAM_REGEX_SEGMENT_PATTERN =
             Pattern.compile(

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/services/PathString.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/services/PathString.java
@@ -17,18 +17,9 @@
 package com.palantir.conjure.parser.services;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Splitter;
 import com.palantir.conjure.defs.ConjureImmutablesStyle;
 import com.palantir.util.syntacticpath.Path;
 import com.palantir.util.syntacticpath.Paths;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.regex.Pattern;
-import org.glassfish.jersey.uri.UriTemplate;
-import org.glassfish.jersey.uri.internal.UriTemplateParser;
 import org.immutables.value.Value;
 
 /** Represents a HTTP path in a {@link ServiceDefinition conjure service definition}. */
@@ -38,64 +29,6 @@ public abstract class PathString {
 
     /** Returns the well-formed path associated with this path definition. */
     public abstract Path path();
-
-    private static final Pattern SEGMENT_PATTERN = Pattern.compile("^[a-zA-Z][a-zA-Z0-9._-]*$");
-    private static final Pattern PARAM_SEGMENT_PATTERN = Pattern.compile("^\\{" + ParameterName.PATTERN + "}$");
-    private static final Pattern PARAM_REGEX_SEGMENT_PATTERN =
-            Pattern.compile(
-                    "^\\{" + ParameterName.PATTERN + "(" + Pattern.quote(":.+") + "|" + Pattern.quote(":.*") + ")"
-                            + "}$");
-
-    /** Creates a new instance if the syntax is correct. */
-    @Value.Check
-    protected final void check() {
-        Preconditions.checkArgument(path().isAbsolute(),
-                "Conjure paths must be absolute, i.e., start with '/': %s", path());
-        Preconditions.checkArgument(path().getSegments().isEmpty() || !path().isFolder(),
-                "Conjure paths must not end with a '/': %s", path());
-
-        for (String segment : path().getSegments()) {
-            Preconditions.checkArgument(
-                    SEGMENT_PATTERN.matcher(segment).matches()
-                            || PARAM_SEGMENT_PATTERN.matcher(segment).matches()
-                            || PARAM_REGEX_SEGMENT_PATTERN.matcher(segment).matches(),
-                    "Segment %s of path %s did not match required segment patterns %s or parameter name "
-                            + "patterns %s or %s",
-                    segment, path(), SEGMENT_PATTERN, PARAM_SEGMENT_PATTERN, PARAM_REGEX_SEGMENT_PATTERN);
-        }
-
-        // verify that path template variables are unique
-        Set<String> templateVars = new HashSet<>();
-        new UriTemplate(path().toString()).getTemplateVariables().stream().forEach(var -> {
-            Preconditions.checkState(!templateVars.contains(var),
-                    "Path parameter %s appears more than once in path %s", var, path());
-            templateVars.add(var);
-        });
-
-        UriTemplateParser uriTemplateParser = new UriTemplateParser(path().toString());
-        Map<String, Pattern> nameToPattern = uriTemplateParser.getNameToPattern();
-        List<String> segments = Splitter.on('/').splitToList(uriTemplateParser.getNormalizedTemplate());
-        for (int i = 0; i < segments.size(); i++) {
-            String segment = segments.get(i);
-            if (!(segment.startsWith("{") && segment.endsWith("}"))) {
-                // path literal
-                continue;
-            }
-
-            // variable
-            Pattern varPattern = nameToPattern.get(segment.substring(1, segment.length() - 1));
-            if (varPattern.equals(UriTemplateParser.TEMPLATE_VALUE_PATTERN)) {
-                // no regular expression specified -- OK
-                continue;
-            }
-
-            // if regular expression was specified, it must be ".+" or ".*" based on invariant previously enforced
-            Preconditions.checkState(i == segments.size() - 1 || !varPattern.pattern().equals(".*"),
-                    "Path parameter %s in path %s specifies regular expression %s, but this regular "
-                            + "expression is only permitted if the path parameter is the last segment", segment,
-                    path(), varPattern);
-        }
-    }
 
     /**
      * Returns this path "concatenated" with the given other path. For example, {@code "/abc".resolve("/def")} is the

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/validator/HttpPathValidatorTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/validator/HttpPathValidatorTest.java
@@ -51,7 +51,7 @@ public final class HttpPathValidatorTest {
             assertThatThrownBy(() -> validate(currCase.path))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage(String.format("Segment %s of path %s did not match required segment patterns "
-                                    + "^[a-zA-Z][a-zA-Z0-9_-]*$ or parameter name patterns "
+                                    + "^[a-zA-Z][a-zA-Z0-9._-]*$ or parameter name patterns "
                                     + "^\\{[a-z][a-z0-9]*([A-Z0-9][a-z0-9]+)*}$ or "
                                     + "^\\{[a-z][a-z0-9]*([A-Z0-9][a-z0-9]+)*"
                                     + "(" + Pattern.quote(":.+") + "|" + Pattern.quote(":.*") + ")"

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/validator/HttpPathValidatorTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/validator/HttpPathValidatorTest.java
@@ -75,6 +75,7 @@ public final class HttpPathValidatorTest {
         validate("/{foo}");
         validate("/abc/{foo}/bar");
         validate("/abc/{foo:.+}");
+        validate("/abc/v1.2/{foo}");
     }
 
     private static void validate(String path) {

--- a/conjure-core/src/test/java/com/palantir/conjure/parser/services/ServiceDefinitionTests.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/parser/services/ServiceDefinitionTests.java
@@ -78,7 +78,7 @@ public final class ServiceDefinitionTests {
     @Test
     public void testEndpointDefinition_fullySpecified() throws IOException, ParseException {
         assertThat(mapper.readValue(multiLineString(
-                "http: GET /{foo}",
+                "http: GET /{foo}/v1.2/path",
                 "auth: header",
                 "args:",
                 "  arg:",
@@ -90,7 +90,7 @@ public final class ServiceDefinitionTests {
                 "docs: |",
                 "  docs"), EndpointDefinition.class))
                 .isEqualTo(EndpointDefinition.builder()
-                        .http(RequestLineDefinition.of("GET", PathString.of("/{foo}")))
+                        .http(RequestLineDefinition.of("GET", PathString.of("/{foo}/v1.2/path")))
                         .auth(AuthDefinition.header())
                         .args(ImmutableMap.of(
                                 ParameterName.of("arg"), ArgumentDefinition.builder()

--- a/conjure-core/src/test/resources/spec-tests/endpoint_path_args.yml
+++ b/conjure-core/src/test/resources/spec-tests/endpoint_path_args.yml
@@ -97,7 +97,7 @@ negative:
               args:
                 arg: string
   regexpMustBeMatchAll:
-    expected-error: 'Segment {arg:[0-9]+} of path /path/{arg:[0-9]+} did not match required segment patterns ^[a-zA-Z][a-zA-Z0-9_-]*$ or parameter name patterns ^\{[a-z][a-z0-9]*([A-Z0-9][a-z0-9]+)*}$ or ^\{[a-z][a-z0-9]*([A-Z0-9][a-z0-9]+)*(\Q:.+\E|\Q:.*\E)}$'
+    expected-error: 'Segment {arg:[0-9]+} of path /path/{arg:[0-9]+} did not match required segment patterns ^[a-zA-Z][a-zA-Z0-9._-]*$ or parameter name patterns ^\{[a-z][a-z0-9]*([A-Z0-9][a-z0-9]+)*}$ or ^\{[a-z][a-z0-9]*([A-Z0-9][a-z0-9]+)*(\Q:.+\E|\Q:.*\E)}$'
     conjure:
       services:
         TestService:
@@ -169,7 +169,7 @@ negative:
               # invalid: "arg" must be defined as a parameter
               http: GET /path/{arg}
   pathTemplateParamNestedBraces:
-    expected-error: 'Segment {{arg}} of path /path/{{arg}}/trailer did not match required segment patterns ^[a-zA-Z][a-zA-Z0-9_-]*$ or parameter name patterns ^\{[a-z][a-z0-9]*([A-Z0-9][a-z0-9]+)*}$ or ^\{[a-z][a-z0-9]*([A-Z0-9][a-z0-9]+)*(\Q:.+\E|\Q:.*\E)}$'
+    expected-error: 'Segment {{arg}} of path /path/{{arg}}/trailer did not match required segment patterns ^[a-zA-Z][a-zA-Z0-9._-]*$ or parameter name patterns ^\{[a-z][a-z0-9]*([A-Z0-9][a-z0-9]+)*}$ or ^\{[a-z][a-z0-9]*([A-Z0-9][a-z0-9]+)*(\Q:.+\E|\Q:.*\E)}$'
     conjure:
       services:
         TestService:
@@ -182,7 +182,7 @@ negative:
               args:
                 arg: string
   pathParamUnbalancedBraces:
-    expected-error: 'Segment {{arg} of path /path/{{arg}/trailer did not match required segment patterns ^[a-zA-Z][a-zA-Z0-9_-]*$ or parameter name patterns ^\{[a-z][a-z0-9]*([A-Z0-9][a-z0-9]+)*}$ or ^\{[a-z][a-z0-9]*([A-Z0-9][a-z0-9]+)*(\Q:.+\E|\Q:.*\E)}$'
+    expected-error: 'Segment {{arg} of path /path/{{arg}/trailer did not match required segment patterns ^[a-zA-Z][a-zA-Z0-9._-]*$ or parameter name patterns ^\{[a-z][a-z0-9]*([A-Z0-9][a-z0-9]+)*}$ or ^\{[a-z][a-z0-9]*([A-Z0-9][a-z0-9]+)*(\Q:.+\E|\Q:.*\E)}$'
     conjure:
       services:
         TestService:

--- a/docs/spec/conjure_definitions.md
+++ b/docs/spec/conjure_definitions.md
@@ -305,7 +305,7 @@ endpoints | Map[`string`&nbsp;&rarr;&nbsp;[EndpointDefinition][]] | **REQUIRED**
 
 ## PathString
 [PathString]: #pathstring
-A PathString consists of segments separated by forward slashes, `/`. Segments may be literals or path parameters (see below).
+A PathString consists of segments separated by forward slashes, `/`. Segments may be literals (any alphanumeric string beginning with a letter and may contain the characters `.`, `_`, `-`) or path parameters (see below).
 
 When comparing multiple paths, the path with the longest concrete path should be matched first.
 


### PR DESCRIPTION
## Before this PR
IR compilation would break if a service endpoint have a path definition of `some/v1.2/path`

## After this PR
Allows `.`s in the path, fixes #177 

@iamdanfox 
