### PR TITLE
[improvement] Allow single character field names

### DIFF
--- a/conjure-core/src/main/java/com/palantir/conjure/parser/types/names/FieldName.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/types/names/FieldName.java
@@ -39,11 +39,11 @@ public abstract class FieldName {
     private static final Logger log = LoggerFactory.getLogger(FieldName.class);
 
     private static final Pattern CAMEL_CASE_PATTERN =
-            Pattern.compile("^[a-z]([A-Z]{1,2}[a-z0-9]|[a-z0-9])+[A-Z]?$");
+            Pattern.compile("^[a-z]([A-Z]{1,2}[a-z0-9]|[a-z0-9])*[A-Z]?$");
     private static final Pattern KEBAB_CASE_PATTERN =
-            Pattern.compile("^[a-z]((-[a-z]){1,2}[a-z0-9]|[a-z0-9])+(-[a-z])?$");
+            Pattern.compile("^[a-z]((-[a-z]){1,2}[a-z0-9]|[a-z0-9])*(-[a-z])?$");
     private static final Pattern SNAKE_CASE_PATTERN =
-            Pattern.compile("^[a-z]((_[a-z]){1,2}[a-z0-9]|[a-z0-9])+(_[a-z])?$");
+            Pattern.compile("^[a-z]((_[a-z]){1,2}[a-z0-9]|[a-z0-9])*(_[a-z])?$");
 
     public enum Case {
         LOWER_CAMEL_CASE(CAMEL_CASE_PATTERN) {


### PR DESCRIPTION

## Before this PR
Single character field names were not allowed (eg: `Point { x, y }`)

## After this PR
Allows single character field names.
