### PR TITLE
Unify regex's

### DIFF
--- a/conjure-generator-common/src/main/java/com/palantir/conjure/CaseConverter.java
+++ b/conjure-generator-common/src/main/java/com/palantir/conjure/CaseConverter.java
@@ -9,11 +9,11 @@ import java.util.regex.Pattern;
 
 public final class CaseConverter {
     public static final Pattern CAMEL_CASE_PATTERN =
-            Pattern.compile("^[a-z]([A-Z]{1,2}[a-z0-9]|[a-z0-9])+[A-Z]?$");
+            Pattern.compile("^[a-z]([A-Z]{1,2}[a-z0-9]|[a-z0-9])*[A-Z]?$");
     public static final Pattern KEBAB_CASE_PATTERN =
-            Pattern.compile("^[a-z]((-[a-z]){1,2}[a-z0-9]|[a-z0-9])+(-[a-z])?$");
+            Pattern.compile("^[a-z]((-[a-z]){1,2}[a-z0-9]|[a-z0-9])*(-[a-z])?$");
     public static final Pattern SNAKE_CASE_PATTERN =
-            Pattern.compile("^[a-z]((_[a-z]){1,2}[a-z0-9]|[a-z0-9])+(_[a-z])?$");
+            Pattern.compile("^[a-z]((_[a-z]){1,2}[a-z0-9]|[a-z0-9])*(_[a-z])?$");
 
     private CaseConverter() {}
 


### PR DESCRIPTION
There should only be one source of the regex's?

<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->

Regex's for field names are not the same.

## After this PR
<!-- Describe at a high-level why this approach is better. -->

Regex's for field name validation are now the same.  Going to actually take a look at why the patterns are in 2 different places...

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
