### PR TITLE
[fix] Get rid of the patterns in FieldName to allow single character field names

### DIFF
--- a/conjure-core/src/main/java/com/palantir/conjure/parser/types/names/FieldName.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/types/names/FieldName.java
@@ -22,7 +22,6 @@ import com.google.common.base.Preconditions;
 import com.palantir.conjure.CaseConverter;
 import com.palantir.conjure.defs.ConjureImmutablesStyle;
 import com.palantir.conjure.parser.types.complex.ObjectTypeDefinition;
-import java.util.Arrays;
 import org.apache.commons.lang3.StringUtils;
 import org.immutables.value.Value;
 import org.slf4j.Logger;
@@ -43,14 +42,19 @@ public abstract class FieldName {
     @Value.Check
     @SuppressWarnings("Slf4jLogsafeArgs")
     protected final void check() {
-        Preconditions.checkArgument(
-                CaseConverter.Case.LOWER_CAMEL_CASE.getPattern().matcher(name()).matches()
-                        || CaseConverter.Case.KEBAB_CASE.getPattern().matcher(name()).matches()
-                        || CaseConverter.Case.SNAKE_CASE.getPattern().matcher(name()).matches(),
-                "FieldName \"%s\" must follow one of the following patterns: %s",
-                name(), Arrays.toString(CaseConverter.Case.values()));
 
-        if (!CaseConverter.Case.LOWER_CAMEL_CASE.getPattern().matcher(name()).matches()) {
+        CaseConverter.Case lowerCamelCase = CaseConverter.Case.LOWER_CAMEL_CASE;
+        CaseConverter.Case kebabCase = CaseConverter.Case.KEBAB_CASE;
+        CaseConverter.Case snakeCase = CaseConverter.Case.SNAKE_CASE;
+
+        Preconditions.checkArgument(
+                lowerCamelCase.getPattern().matcher(name()).matches()
+                        || kebabCase.getPattern().matcher(name()).matches()
+                        || snakeCase.getPattern().matcher(name()).matches(),
+                "FieldName \"%s\" must follow one of the following patterns: %s %s %s",
+                name(), lowerCamelCase, kebabCase, snakeCase);
+
+        if (!lowerCamelCase.getPattern().matcher(name()).matches()) {
             log.warn("{} should be specified in lowerCamelCase. kebab-case and snake_case are supported for "
                     + "legacy endpoints only: {}", FieldName.class, name());
         }

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/validator/FieldNameValidatorTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/validator/FieldNameValidatorTest.java
@@ -51,7 +51,6 @@ public final class FieldNameValidatorTest {
                 "snake_123_case",
                 "kebab-123-case",
                 "mixed-kebab_snake-case",
-                "x",
                 "defaultDNSName"
                 }) {
             assertThatThrownBy(() -> FieldNameValidator.validate(FieldName.of(invalid)))

--- a/conjure-generator-common/src/main/java/com/palantir/conjure/CaseConverter.java
+++ b/conjure-generator-common/src/main/java/com/palantir/conjure/CaseConverter.java
@@ -9,11 +9,11 @@ import java.util.regex.Pattern;
 
 public final class CaseConverter {
     public static final Pattern CAMEL_CASE_PATTERN =
-            Pattern.compile("^[a-z]([A-Z]{1,2}[a-z0-9]|[a-z0-9])+[A-Z]?$");
+            Pattern.compile("^[a-z]([A-Z]{1,2}[a-z0-9]|[a-z0-9])*[A-Z]?$");
     public static final Pattern KEBAB_CASE_PATTERN =
-            Pattern.compile("^[a-z]((-[a-z]){1,2}[a-z0-9]|[a-z0-9])+(-[a-z])?$");
+            Pattern.compile("^[a-z]((-[a-z]){1,2}[a-z0-9]|[a-z0-9])*(-[a-z])?$");
     public static final Pattern SNAKE_CASE_PATTERN =
-            Pattern.compile("^[a-z]((_[a-z]){1,2}[a-z0-9]|[a-z0-9])+(_[a-z])?$");
+            Pattern.compile("^[a-z]((_[a-z]){1,2}[a-z0-9]|[a-z0-9])*(_[a-z])?$");
 
     private CaseConverter() {}
 


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->

## Before this PR
<!-- Describe the problem you encountered with the current state of the world (or link to an issue) and why it's important to fix now. -->

There were 2 validations for field names.  A previous PR attempted to allow single character field names, but there were 2 places validations happened.

## After this PR
<!-- Describe at a high-level why this approach is better. -->

Allow single character field names and prevent the issue from happening again by having only 1 source of truth for the validation patterns.

<!-- Reference any existing GitHub issues, e.g. 'fixes #000' or 'relevant to #000' -->
