### PR TITLE
[improvement] EndpointDefinition validation errors include the endpoint name and path

### DIFF
--- a/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ArgumentNameValidatorTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ArgumentNameValidatorTest.java
@@ -53,9 +53,9 @@ public final class ArgumentNameValidatorTest {
             EndpointDefinition.Builder endpoint = createEndpoint(paramName);
             assertThatThrownBy(() -> EndpointDefinitionValidator.validateAll(endpoint.build(), dealiasingVisitor))
                     .isInstanceOf(IllegalStateException.class)
-                    .hasMessage("Parameter names in endpoint paths and service definitions must match pattern %s: %s",
-                            EndpointDefinitionValidator.ANCHORED_PATTERN,
-                            paramName);
+                    .hasMessage("Parameter names in endpoint paths and service definitions "
+                                    + "must match pattern %s: %s on endpoint test{http: POST /a/path}",
+                            EndpointDefinitionValidator.ANCHORED_PATTERN, paramName);
         }
     }
 

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/validator/EndpointDefinitionTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/validator/EndpointDefinitionTest.java
@@ -97,7 +97,8 @@ public final class EndpointDefinitionTest {
 
         assertThatThrownBy(() -> EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessage("Endpoint cannot have multiple body parameters: [bodyArg1, bodyArg2]");
+                .hasMessage("Endpoint 'test{http: GET /a/path}' cannot have multiple body parameters: "
+                        + "[bodyArg1, bodyArg2]");
     }
 
     @Test
@@ -114,8 +115,8 @@ public final class EndpointDefinitionTest {
 
         assertThatThrownBy(() -> EndpointDefinitionValidator.validateAll(definition, emptyDealiasingVisitor))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessage("Endpoint BODY argument must not be optional<binary> or alias thereof: method: POST, "
-                        + "path: /a/path");
+                .hasMessage("Endpoint BODY argument must not be optional<binary> or alias thereof: "
+                        + "test{http: POST /a/path}");
     }
 
     @Test
@@ -137,8 +138,8 @@ public final class EndpointDefinitionTest {
 
         assertThatThrownBy(() -> EndpointDefinitionValidator.validateAll(definition, dealiasingVisitor))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessage("Endpoint BODY argument must not be optional<binary> or alias thereof: method: POST, "
-                        + "path: /a/path");
+                .hasMessage("Endpoint BODY argument must not be optional<binary> or alias thereof: "
+                        + "test{http: POST /a/path}");
     }
 
     @Test
@@ -162,7 +163,8 @@ public final class EndpointDefinitionTest {
 
         assertThatThrownBy(() -> EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessage("Path parameter with identifier \"paramName\" is defined multiple times for endpoint");
+                .hasMessage("Path parameter with identifier \"paramName\" is "
+                        + "defined multiple times for endpoint test{http: GET /a/path}");
     }
 
     @Test
@@ -194,7 +196,8 @@ public final class EndpointDefinitionTest {
 
         assertThatThrownBy(() -> EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessage("Path parameters defined path template but not present in endpoint: [paramName]");
+                .hasMessage("Path parameters [paramName] defined path template but not present in endpoint: "
+                        + "test{http: GET /a/path/{paramName}}");
     }
 
     @Test
@@ -207,10 +210,7 @@ public final class EndpointDefinitionTest {
 
         assertThatThrownBy(() -> EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessage(String.format(
-                        "Endpoint cannot be a GET and contain a body: method: %s, path: %s",
-                        HttpMethod.GET,
-                        "/a/path"));
+                .hasMessage("Endpoint 'test{http: GET /a/path}' cannot be a GET and contain a body");
     }
 
     @Test
@@ -227,8 +227,8 @@ public final class EndpointDefinitionTest {
 
         assertThatThrownBy(() -> EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessage("Header parameters must be enums, primitives, aliases or optional primitive:"
-                        + " \"someName\" is not allowed");
+                .hasMessage("Header parameters must be enums, primitives, aliases or optional primitive: "
+                        + "\"someName\" is not allowed on endpoint test{http: GET /a/path}");
     }
 
     @Test
@@ -250,7 +250,7 @@ public final class EndpointDefinitionTest {
 
         assertThatThrownBy(() -> EndpointDefinitionValidator.validateAll(definition.build(), dealiasingVisitor))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessage("Header parameters must be enums, primitives, aliases or optional primitive:"
-                        + " \"someName\" is not allowed");
+                .hasMessage("Header parameters must be enums, primitives, aliases or optional primitive: "
+                        + "\"someName\" is not allowed on endpoint test{http: GET /a/path}");
     }
 }

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ParamIdValidatorTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ParamIdValidatorTest.java
@@ -70,7 +70,8 @@ public final class ParamIdValidatorTest {
             ParameterType parameterType = ParameterType.query(QueryParameterType.of(ParameterId.of(paramId)));
             assertThatThrownBy(() -> createEndpoint(parameterType))
                     .isInstanceOf(IllegalStateException.class)
-                    .hasMessage("Parameter ids with type %s must match pattern %s: %s",
+                    .hasMessage("Parameter ids with type %s must match pattern %s: %s "
+                                    + "on endpoint test{http: POST /a/path}",
                             parameterType,
                             EndpointDefinitionValidator.ANCHORED_PATTERN,
                             paramId);
@@ -83,7 +84,8 @@ public final class ParamIdValidatorTest {
             ParameterType parameterType = ParameterType.header(HeaderParameterType.of(ParameterId.of(paramId)));
             assertThatThrownBy(() -> createEndpoint(parameterType))
                     .isInstanceOf(IllegalStateException.class)
-                    .hasMessage("Parameter ids with type %s must match pattern %s: %s",
+                    .hasMessage("Parameter ids with type %s must match pattern %s: %s "
+                                    + "on endpoint test{http: POST /a/path}",
                             parameterType,
                             EndpointDefinitionValidator.HEADER_PATTERN,
                             paramId);

--- a/conjure-core/src/test/resources/spec-tests/endpoint_body_args.yml
+++ b/conjure-core/src/test/resources/spec-tests/endpoint_body_args.yml
@@ -1,7 +1,7 @@
 test-case-name: "service endpoint argument tests"
 negative:
   multipleAutoArgsThatResolveToBody:
-    expected-error: 'Endpoint cannot have multiple body parameters: [arg, arg2]'
+    expected-error: "Endpoint 'testEndpoint{http: GET /path}' cannot have multiple body parameters: [arg, arg2]"
     conjure:
       services:
         TestService:
@@ -15,7 +15,7 @@ negative:
                 arg: string
                 arg2: string
   multipleBodyParams:
-    expected-error: 'Endpoint cannot have multiple body parameters: [arg, arg2]'
+    expected-error: "Endpoint 'testEndpoint{http: GET /path}' cannot have multiple body parameters: [arg, arg2]"
     conjure:
       services:
         TestService:
@@ -33,7 +33,7 @@ negative:
                   type: string
                   param-type: body
   bodyAndAutoParam:
-    expected-error: 'Endpoint cannot have multiple body parameters: [arg, arg2]'
+    expected-error: "Endpoint 'testEndpoint{http: GET /path}' cannot have multiple body parameters: [arg, arg2]"
     conjure:
       services:
         TestService:
@@ -49,7 +49,7 @@ negative:
                   type: string
                   param-type: body
   bodyParamAndPathParam:
-    expected-error: 'Endpoint cannot be a GET and contain a body'
+    expected-error: "Endpoint 'testEndpoint{http: GET /path/{arg}}' cannot be a GET and contain a body"
     conjure:
       services:
         TestService:

--- a/conjure-core/src/test/resources/spec-tests/endpoint_path_args.yml
+++ b/conjure-core/src/test/resources/spec-tests/endpoint_path_args.yml
@@ -158,7 +158,7 @@ negative:
                 other: string
                 other2: string
   pathTemplateParamMissing:
-    expected-error: "Path parameters defined path template but not present in endpoint: [arg]"
+    expected-error: "Path parameters [arg] defined path template but not present in endpoint: testEndpoint{http: GET /path/{arg}}"
     conjure:
       services:
         TestService:


### PR DESCRIPTION
## Before this PR
Previously it was difficult to tell which endpoint caused validation
to fail.

## After this PR
==COMMIT_MSG==
EndpointDefinition validation errors include the endpoint name and path
==COMMIT_MSG==
