### PR TITLE
[Fix] Clarify what parameter types are allowed for path/query/header

### DIFF
--- a/docs/spec/conjure_definitions.md
+++ b/docs/spec/conjure_definitions.md
@@ -357,10 +357,9 @@ An object representing an argument to an endpoint.
 Field | Type | Description
 ---|:---:|---
 type | [ConjureType][] | **REQUIRED**. The type of the value of the argument. The type name MUST exist within the Conjure definition. If this ArgumentDefinition has a param-type of `body` then there are no restrictions on the type. 
-If the param-type is `path` then the de-aliased type MUST be an enum or a primitive (except binary).
-If the param-type is `query` then the de-aliased type MUST be an enum or a primitive (except binary), or a container (list, set, optional) of one of these.
+If the param-type is `path` then the de-aliased type MUST be an enum or a primitive (except `binary`, and `bearertoken`).
+If the param-type is `query` then the de-aliased type MUST be an enum or a primitive (except `binary` and `bearertoken`), or a container (list, set, optional) of one of these.
 If the param-type is `header` then the de-aliased type MUST be an enum or a primitive (except binary), or an optional of one of these.
-Additionally, the type MUST NOT be `bearertoken` when the param-type is `path` or `query`.
 markers | List[`string`] | List of types that serve as additional metadata for the argument. If the value of the field is a `string` it MUST be a type name that exists within the Conjure definition.
 deprecated | `string` | Documentation for why this argument is deprecated. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 param&#8209;id | `string` | An identifier to use as a parameter value. If the param type is `header` or `query`, this field may be populated to define the identifier that is used over the wire. If this field is undefined for the `header` or `query` param types, the argument name is used as the wire identifier. Population of this field is invalid if the param type is not `header` or `query`.

--- a/docs/spec/conjure_definitions.md
+++ b/docs/spec/conjure_definitions.md
@@ -356,7 +356,11 @@ An object representing an argument to an endpoint.
 
 Field | Type | Description
 ---|:---:|---
-type | [ConjureType][] | **REQUIRED**. The type of the value of the argument. The type name MUST exist within the Conjure definition. If this ArgumentDefinition has a param-type of `body` then there are no restrictions on the type. If the param-type is `path`, `header` or `query` then the de-aliased type MUST be an enum, a primitive or an optional of one of these. `query` type parameters may accept lists and sets in addition to optional containers. Additionally, the type MUST NOT be `bearertoken` when the param-type is `header` or `query`.
+type | [ConjureType][] | **REQUIRED**. The type of the value of the argument. The type name MUST exist within the Conjure definition. If this ArgumentDefinition has a param-type of `body` then there are no restrictions on the type. 
+If the param-type is `path` then the de-aliased type MUST be an enum or a primitive.
+If the param-type is `query` then the de-aliased type MUST be an enum or a primitive, or a container (list, set, optional) of one of these.
+If the param-type is `header` then the de-aliased type MUST be an enum or a primitive, or an optional of one of these.
+Additionally, the type MUST NOT be `bearertoken` when the param-type is `path` or `query`.
 markers | List[`string`] | List of types that serve as additional metadata for the argument. If the value of the field is a `string` it MUST be a type name that exists within the Conjure definition.
 deprecated | `string` | Documentation for why this argument is deprecated. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 param&#8209;id | `string` | An identifier to use as a parameter value. If the param type is `header` or `query`, this field may be populated to define the identifier that is used over the wire. If this field is undefined for the `header` or `query` param types, the argument name is used as the wire identifier. Population of this field is invalid if the param type is not `header` or `query`.

--- a/docs/spec/conjure_definitions.md
+++ b/docs/spec/conjure_definitions.md
@@ -357,9 +357,9 @@ An object representing an argument to an endpoint.
 Field | Type | Description
 ---|:---:|---
 type | [ConjureType][] | **REQUIRED**. The type of the value of the argument. The type name MUST exist within the Conjure definition. If this ArgumentDefinition has a param-type of `body` then there are no restrictions on the type. 
-If the param-type is `path` then the de-aliased type MUST be an enum or a primitive.
-If the param-type is `query` then the de-aliased type MUST be an enum or a primitive, or a container (list, set, optional) of one of these.
-If the param-type is `header` then the de-aliased type MUST be an enum or a primitive, or an optional of one of these.
+If the param-type is `path` then the de-aliased type MUST be an enum or a primitive (except binary).
+If the param-type is `query` then the de-aliased type MUST be an enum or a primitive (except binary), or a container (list, set, optional) of one of these.
+If the param-type is `header` then the de-aliased type MUST be an enum or a primitive (except binary), or an optional of one of these.
 Additionally, the type MUST NOT be `bearertoken` when the param-type is `path` or `query`.
 markers | List[`string`] | List of types that serve as additional metadata for the argument. If the value of the field is a `string` it MUST be a type name that exists within the Conjure definition.
 deprecated | `string` | Documentation for why this argument is deprecated. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.


### PR DESCRIPTION
## Before this PR
The spec does not reflect the intent and the reality as per https://github.com/palantir/conjure/blob/master/conjure-core/src/main/java/com/palantir/conjure/defs/validator/EndpointDefinitionValidator.java .

## After this PR
The spec matches the intent and the reality as per https://github.com/palantir/conjure/blob/master/conjure-core/src/main/java/com/palantir/conjure/defs/validator/EndpointDefinitionValidator.java .
