### PR TITLE
Updated docs to remove deprecated from argument

### DIFF
--- a/docs/spec/conjure_definitions.md
+++ b/docs/spec/conjure_definitions.md
@@ -361,7 +361,6 @@ If the param-type is `path` then the de-aliased type MUST be an enum or a primit
 If the param-type is `query` then the de-aliased type MUST be an enum or a primitive (except `binary` and `bearertoken`), or a container (list, set, optional) of one of these.
 If the param-type is `header` then the de-aliased type MUST be an enum or a primitive (except binary), or an optional of one of these.
 markers | List[`string`] | List of types that serve as additional metadata for the argument. If the value of the field is a `string` it MUST be a type name that exists within the Conjure definition.
-deprecated | `string` | Documentation for why this argument is deprecated. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 param&#8209;id | `string` | An identifier to use as a parameter value. If the param type is `header` or `query`, this field may be populated to define the identifier that is used over the wire. If this field is undefined for the `header` or `query` param types, the argument name is used as the wire identifier. Population of this field is invalid if the param type is not `header` or `query`.
 param&#8209;type | [ArgumentDefinition.ParamType][] | The type of the endpoint parameter. If omitted the default type is `auto`.
 


### PR DESCRIPTION
Appears as though this is no longer a part of [`ArugmentDefinition`](https://github.com/palantir/conjure/blob/master/conjure-core/src/main/java/com/palantir/conjure/parser/services/ArgumentDefinition.java)
