### PR TITLE
[improvement] Allow legacy kebab-case and snake_case query params

### DIFF
--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/EndpointDefinitionValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/EndpointDefinitionValidator.java
@@ -372,7 +372,7 @@ public enum EndpointDefinitionValidator implements ConjureContextualValidator<En
             definition.getArgs().forEach(arg -> {
                 ParameterType paramType = arg.getParamType();
                 if (paramType.accept(ParameterTypeVisitor.IS_BODY) || paramType.accept(ParameterTypeVisitor.IS_PATH)) {
-                    // No validation
+                    // No validation for param-id of body and path parameters, as it is never (de)serialized.
                 } else if (paramType.accept(ParameterTypeVisitor.IS_HEADER)) {
                     ParameterId paramId = paramType.accept(ParameterTypeVisitor.HEADER).getParamId();
                     Preconditions.checkState(HEADER_PATTERN.matcher(paramId.get()).matches(),

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ArgumentNameValidatorTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ArgumentNameValidatorTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.palantir.conjure.CaseConverter;
 import com.palantir.conjure.spec.ArgumentDefinition;
 import com.palantir.conjure.spec.ArgumentName;
 import com.palantir.conjure.spec.BodyParameterType;
@@ -55,7 +56,7 @@ public final class ArgumentNameValidatorTest {
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessage("Parameter names in endpoint paths and service definitions "
                                     + "must match pattern %s: %s on endpoint test{http: POST /a/path}",
-                            EndpointDefinitionValidator.ANCHORED_PATTERN, paramName);
+                            CaseConverter.CAMEL_CASE_PATTERN, paramName);
         }
     }
 


### PR DESCRIPTION
<!-- PR title should start with '[fix]', '[improvement]' or '[break]' if this PR would cause a patch, minor or major SemVer bump. Omit the prefix if this PR doesn't warrant a standalone release. -->
Fixes #48

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Validation for query parameters is more strict than for JSON field names.
## After this PR
Endpoint validation allows legacy kebab-case and snake_case query params but logs a warning.

## Possible downsides?
New APIs may accidentally use legacy argument formats. This is mitigated with a logged warning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/conjure/299)
<!-- Reviewable:end -->
