### PR TITLE
[fix] Emit IR with types, services and errors sorted by type name

### DIFF
--- a/conjure-core/src/main/java/com/palantir/conjure/defs/Conjure.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/Conjure.java
@@ -17,9 +17,12 @@
 package com.palantir.conjure.defs;
 
 import com.palantir.conjure.parser.ConjureParser;
+import com.palantir.conjure.parser.ConjureSourceFile;
+import com.palantir.conjure.parser.NormalizeDefinition;
 import com.palantir.conjure.spec.ConjureDefinition;
 import java.io.File;
 import java.util.Collection;
+import java.util.List;
 import java.util.stream.Collectors;
 
 public final class Conjure {
@@ -31,7 +34,8 @@ public final class Conjure {
      * Deserializes {@link ConjureDefinition} from their YAML representations in the given files.
      */
     public static ConjureDefinition parse(Collection<File> files) {
-        return ConjureParserUtils.parseConjureDef(
-                files.stream().map(ConjureParser::parse).collect(Collectors.toList()));
+        List<ConjureSourceFile> sourceFiles = files.stream().map(ConjureParser::parse).collect(Collectors.toList());
+        ConjureDefinition ir = ConjureParserUtils.parseConjureDef(sourceFiles);
+        return NormalizeDefinition.normalize(ir);
     }
 }

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/NormalizeDefinition.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/NormalizeDefinition.java
@@ -45,8 +45,8 @@ public final class NormalizeDefinition {
     }
 
     private static List<ServiceDefinition> sortServiceDefinitions(List<ServiceDefinition> services) {
-        // we intentionally don't sort the Endpoints _within_ a ServiceDefinition, because these can be preserved
-        // from the source yml
+        // we intentionally don't sort the Endpoints _within_ a ServiceDefinition, because we want to preserve
+        // the endpoint order that the API author wrote in their source.yml
         return services.stream()
                 .sorted(Comparator.comparing(def -> typeNameToString(def.getServiceName())))
                 .collect(Collectors.toList());

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/NormalizeDefinition.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/NormalizeDefinition.java
@@ -1,0 +1,66 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.parser;
+
+import com.palantir.conjure.spec.ConjureDefinition;
+import com.palantir.conjure.spec.ErrorDefinition;
+import com.palantir.conjure.spec.ServiceDefinition;
+import com.palantir.conjure.spec.TypeDefinition;
+import com.palantir.conjure.spec.TypeName;
+import com.palantir.conjure.visitor.TypeDefinitionVisitor;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public final class NormalizeDefinition {
+
+    /** Ensures the order of types, services and endpoints is sorted. */
+    public static ConjureDefinition normalize(ConjureDefinition input) {
+        return ConjureDefinition.builder()
+                .version(input.getVersion())
+                .types(sortTypeDefinitions(input.getTypes()))
+                .services(sortServiceDefinitions(input.getServices()))
+                .errors(sortErrorDefinitions(input.getErrors()))
+                .build();
+    }
+
+    private static List<TypeDefinition> sortTypeDefinitions(List<TypeDefinition> types) {
+        return types.stream()
+                .sorted(Comparator.comparing(def -> typeNameToString(def.accept(TypeDefinitionVisitor.TYPE_NAME))))
+                .collect(Collectors.toList());
+    }
+
+    private static List<ServiceDefinition> sortServiceDefinitions(List<ServiceDefinition> services) {
+        // we intentionally don't sort the Endpoints _within_ a ServiceDefinition, because these can be preserved
+        // from the source yml
+        return services.stream()
+                .sorted(Comparator.comparing(def -> typeNameToString(def.getServiceName())))
+                .collect(Collectors.toList());
+    }
+
+    private static List<ErrorDefinition> sortErrorDefinitions(List<ErrorDefinition> errors) {
+        return errors.stream()
+                .sorted(Comparator.comparing(def -> typeNameToString(def.getErrorName())))
+                .collect(Collectors.toList());
+    }
+
+    private static String typeNameToString(TypeName typeName) {
+        return typeName.getPackage() + "." + typeName.getName();
+    }
+
+    private NormalizeDefinition() {}
+}

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/NormalizeDefinition.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/NormalizeDefinition.java
@@ -28,6 +28,9 @@ import java.util.stream.Collectors;
 
 public final class NormalizeDefinition {
 
+    private static final Comparator<TypeName> TYPE_NAME_COMPARATOR =
+            Comparator.comparing(TypeName::getPackage).thenComparing(TypeName::getName);
+
     /** Ensures the order of types, services and endpoints is sorted. */
     public static ConjureDefinition normalize(ConjureDefinition input) {
         return ConjureDefinition.builder()
@@ -40,7 +43,7 @@ public final class NormalizeDefinition {
 
     private static List<TypeDefinition> sortTypeDefinitions(List<TypeDefinition> types) {
         return types.stream()
-                .sorted(Comparator.comparing(def -> typeNameToString(def.accept(TypeDefinitionVisitor.TYPE_NAME))))
+                .sorted(Comparator.comparing(def -> def.accept(TypeDefinitionVisitor.TYPE_NAME), TYPE_NAME_COMPARATOR))
                 .collect(Collectors.toList());
     }
 
@@ -48,18 +51,14 @@ public final class NormalizeDefinition {
         // we intentionally don't sort the Endpoints _within_ a ServiceDefinition, because we want to preserve
         // the endpoint order that the API author wrote in their source.yml
         return services.stream()
-                .sorted(Comparator.comparing(def -> typeNameToString(def.getServiceName())))
+                .sorted(Comparator.comparing(ServiceDefinition::getServiceName, TYPE_NAME_COMPARATOR))
                 .collect(Collectors.toList());
     }
 
     private static List<ErrorDefinition> sortErrorDefinitions(List<ErrorDefinition> errors) {
         return errors.stream()
-                .sorted(Comparator.comparing(def -> typeNameToString(def.getErrorName())))
+                .sorted(Comparator.comparing(ErrorDefinition::getErrorName, TYPE_NAME_COMPARATOR))
                 .collect(Collectors.toList());
-    }
-
-    private static String typeNameToString(TypeName typeName) {
-        return typeName.getPackage() + "." + typeName.getName();
     }
 
     private NormalizeDefinition() {}

--- a/conjure-core/src/test/java/com/palantir/conjure/parser/NormalizeDefinitionTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/parser/NormalizeDefinitionTest.java
@@ -1,0 +1,50 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.parser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.google.common.collect.ImmutableSet;
+import com.palantir.conjure.defs.Conjure;
+import com.palantir.conjure.spec.ConjureDefinition;
+import java.io.File;
+import java.io.IOException;
+import org.junit.Test;
+
+public class NormalizeDefinitionTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new Jdk8Module());
+
+    @Test
+    public void sort_types_services_and_errors() throws IOException {
+        ConjureDefinition normalized = Conjure.parse(ImmutableSet.of(new File("src/test/resources/normalize-me.yml")));
+
+        String actual = objectMapper
+                .writerWithDefaultPrettyPrinter()
+                .writeValueAsString(normalized);
+
+        File file = new File("src/test/resources/normalized.conjure.json");
+
+        if (Boolean.valueOf(System.getProperty("recreate", "false"))) {
+            objectMapper.writerWithDefaultPrettyPrinter().writeValue(file, normalized);
+        }
+
+        assertThat(file).hasContent(actual);
+    }
+}

--- a/conjure-core/src/test/resources/normalize-me.yml
+++ b/conjure-core/src/test/resources/normalize-me.yml
@@ -1,0 +1,31 @@
+types:
+  definitions:
+    default-package: com.palantir.a
+    objects:
+      Object1:
+        package: com.palantir.a
+        fields:
+          stringField: string
+
+      Object3:
+        package: com.palantir.b
+        alias: string
+
+      Object2:
+        package: com.palantir.b
+        alias: string
+
+services:
+  TestService2:
+    name: Test Service 2
+    package: com.palantir.foo
+    endpoints:
+      get:
+        http: GET /get
+
+  TestService1:
+    name: Test Service 1
+    package: com.palantir.foo
+    endpoints:
+      get:
+        http: GET /get

--- a/conjure-core/src/test/resources/normalize-me.yml
+++ b/conjure-core/src/test/resources/normalize-me.yml
@@ -15,6 +15,19 @@ types:
         package: com.palantir.b
         alias: string
 
+    errors:
+      Error2:
+        namespace: Test
+        code: INVALID_ARGUMENT
+        safe-args:
+          id: integer
+
+      Error1:
+        namespace: Test
+        code: INVALID_ARGUMENT
+        safe-args:
+          id: integer
+
 services:
   TestService2:
     name: Test Service 2

--- a/conjure-core/src/test/resources/normalized.conjure.json
+++ b/conjure-core/src/test/resources/normalized.conjure.json
@@ -1,0 +1,83 @@
+{
+  "version" : 1,
+  "errors" : [ ],
+  "types" : [ {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
+        "name" : "Object1",
+        "package" : "com.palantir.a"
+      },
+      "fields" : [ {
+        "fieldName" : "stringField",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "STRING"
+        },
+        "docs" : null
+      } ],
+      "docs" : null
+    }
+  }, {
+    "type" : "alias",
+    "alias" : {
+      "typeName" : {
+        "name" : "Object2",
+        "package" : "com.palantir.b"
+      },
+      "alias" : {
+        "type" : "primitive",
+        "primitive" : "STRING"
+      },
+      "docs" : null
+    }
+  }, {
+    "type" : "alias",
+    "alias" : {
+      "typeName" : {
+        "name" : "Object3",
+        "package" : "com.palantir.b"
+      },
+      "alias" : {
+        "type" : "primitive",
+        "primitive" : "STRING"
+      },
+      "docs" : null
+    }
+  } ],
+  "services" : [ {
+    "serviceName" : {
+      "name" : "TestService1",
+      "package" : "com.palantir.foo"
+    },
+    "endpoints" : [ {
+      "endpointName" : "get",
+      "httpMethod" : "GET",
+      "httpPath" : "/get",
+      "auth" : null,
+      "args" : [ ],
+      "returns" : null,
+      "docs" : null,
+      "deprecated" : null,
+      "markers" : [ ]
+    } ],
+    "docs" : null
+  }, {
+    "serviceName" : {
+      "name" : "TestService2",
+      "package" : "com.palantir.foo"
+    },
+    "endpoints" : [ {
+      "endpointName" : "get",
+      "httpMethod" : "GET",
+      "httpPath" : "/get",
+      "auth" : null,
+      "args" : [ ],
+      "returns" : null,
+      "docs" : null,
+      "deprecated" : null,
+      "markers" : [ ]
+    } ],
+    "docs" : null
+  } ]
+}

--- a/conjure-core/src/test/resources/normalized.conjure.json
+++ b/conjure-core/src/test/resources/normalized.conjure.json
@@ -1,6 +1,40 @@
 {
   "version" : 1,
-  "errors" : [ ],
+  "errors" : [ {
+    "errorName" : {
+      "name" : "Error1",
+      "package" : "com.palantir.a"
+    },
+    "docs" : null,
+    "namespace" : "Test",
+    "code" : "INVALID_ARGUMENT",
+    "safeArgs" : [ {
+      "fieldName" : "id",
+      "type" : {
+        "type" : "primitive",
+        "primitive" : "INTEGER"
+      },
+      "docs" : null
+    } ],
+    "unsafeArgs" : [ ]
+  }, {
+    "errorName" : {
+      "name" : "Error2",
+      "package" : "com.palantir.a"
+    },
+    "docs" : null,
+    "namespace" : "Test",
+    "code" : "INVALID_ARGUMENT",
+    "safeArgs" : [ {
+      "fieldName" : "id",
+      "type" : {
+        "type" : "primitive",
+        "primitive" : "INTEGER"
+      },
+      "docs" : null
+    } ],
+    "unsafeArgs" : [ ]
+  } ],
   "types" : [ {
     "type" : "object",
     "object" : {


### PR DESCRIPTION
## Before this PR

As mentioned in https://github.com/palantir/conjure/issues/316, within the List<TypeDefinition>, the order was actually undefined.

## After this PR
==COMMIT_MSG==
The conjure CLI will always emit IR with types, services and errors sorted alphabetically by their type name.

We don't sort endpoints or arguments within these definitions, instead prefer to preserve the original source ordering.
==COMMIT_MSG==

fixes https://github.com/palantir/conjure/issues/316

## Possible downsides?


cc @bmoylan 