### PR TITLE
[fix] [DNM] Fix spec to match verification

### DIFF
--- a/docs/spec/wire.md
+++ b/docs/spec/wire.md
@@ -269,7 +269,7 @@ Conjure&nbsp;Type | JSON&nbsp;Type                | Comments |
 ### 5.3. Named types
 Conjure&nbsp;Type | JSON&nbsp;Type | Comments |
 ----------------- | ---------------| -------- |
-_Object_          | Object         | Keys are obtained from the Conjure object's fields and values using `JSON(v)`. For any (key,value) pair where the value is of `optional<?>` type, the key must be omitted from the JSON Object if the value is absent.
+_Object_          | Object         | Keys are obtained from the Conjure object's fields and values using `JSON(v)`. For any (key,value) pair where the value is of `optional<?>` type, the key should be omitted from the JSON Object if the value is absent. Alternatively, the field may be set to `null`.
 _Enum_            | String         | String representation of the enum value
 _Union_           | Object         | (See union JSON format below)
 _Alias_(x)        | `JSON(x)`      | Aliases are serialized exactly the same way as their corresponding de-aliased Conjure types.


### PR DESCRIPTION
DO NOT MERGE BEFORE DISCUSSION HAS BEEN RESOLVED

## Before this PR
According to the [verification code](https://github.com/palantir/conjure-verification/blob/78992dd9a733a5a90b0e3bccd1817380eb00146b/master-test-cases.yml#L208), `null` is acceptable ([conjure type](https://github.com/palantir/conjure-verification/blob/e6410329db974a9268ef6bedd834ae97523731ac/example-types.conjure.yml#L32)). However, the wire spec disagrees & specifies the key must be absent.

## After this PR
==COMMIT_MSG==
The wire spec matches the verification code
==COMMIT_MSG==

## Possible downsides?
If the wire spec is correct, we should be fixing the verification code instead.