### PR TITLE
Add 401 Unauthenticated to conjure error types

### DIFF
--- a/conjure-api/src/main/conjure/conjure-api.yml
+++ b/conjure-api/src/main/conjure/conjure-api.yml
@@ -30,9 +30,9 @@ types:
         alias: string
       ErrorCode:
         values:
+          - INVALID_ARGUMENT
           - UNAUTHENTICATED
           - PERMISSION_DENIED
-          - INVALID_ARGUMENT
           - NOT_FOUND
           - CONFLICT
           - REQUEST_ENTITY_TOO_LARGE

--- a/conjure-api/src/main/conjure/conjure-api.yml
+++ b/conjure-api/src/main/conjure/conjure-api.yml
@@ -30,6 +30,7 @@ types:
         alias: string
       ErrorCode:
         values:
+          - UNAUTHENTICATED
           - PERMISSION_DENIED
           - INVALID_ARGUMENT
           - NOT_FOUND

--- a/docs/spec/conjure_definitions.md
+++ b/docs/spec/conjure_definitions.md
@@ -278,9 +278,9 @@ docs | [DocString][] | Documentation for the type. [CommonMark syntax](http://sp
 ## ErrorCode
 [ErrorCode]: #errorcode
 A field describing the error category. MUST be one of the following strings, with HTTP status codes defined in the [wire spec](/docs/spec/wire.md#34-conjure-errors):
+* INVALID_ARGUMENT
 * UNAUTHENTICATED
 * PERMISSION_DENIED
-* INVALID_ARGUMENT
 * NOT_FOUND
 * CONFLICT
 * REQUEST_ENTITY_TOO_LARGE

--- a/docs/spec/conjure_definitions.md
+++ b/docs/spec/conjure_definitions.md
@@ -278,6 +278,7 @@ docs | [DocString][] | Documentation for the type. [CommonMark syntax](http://sp
 ## ErrorCode
 [ErrorCode]: #errorcode
 A field describing the error category. MUST be one of the following strings, with HTTP status codes defined in the [wire spec](/docs/spec/wire.md#34-conjure-errors):
+* UNAUTHENTICATED
 * PERMISSION_DENIED
 * INVALID_ARGUMENT
 * NOT_FOUND

--- a/docs/spec/wire.md
+++ b/docs/spec/wire.md
@@ -208,6 +208,7 @@ In order to send a Conjure error, servers must serialize the error using the [JS
 
 Conjure Error code         | HTTP Status code |
 -------------------------- | ---------------- |
+UNAUTHENTICATED            | 401
 PERMISSION_DENIED          | 403
 INVALID_ARGUMENT           | 400
 NOT_FOUND                  | 404

--- a/docs/spec/wire.md
+++ b/docs/spec/wire.md
@@ -208,9 +208,9 @@ In order to send a Conjure error, servers must serialize the error using the [JS
 
 Conjure Error code         | HTTP Status code |
 -------------------------- | ---------------- |
+INVALID_ARGUMENT           | 400
 UNAUTHENTICATED            | 401
 PERMISSION_DENIED          | 403
-INVALID_ARGUMENT           | 400
 NOT_FOUND                  | 404
 CONFLICT                   | 409
 REQUEST_ENTITY_TOO_LARGE   | 413


### PR DESCRIPTION
Palantir's authentication service uses 401 in the expected way, but currently clients have to manually propagate these. This PR makes 401 part of the conjure spec, which will let us define it as an `ErrorType` in conjure-java-runtime-api and propagate by default in conjure-java-runtime, similar to 403s.

HTTP names this 401 Unauthorized, however 401 Unauthenticated seems like a clearer name given the way Palantir uses 401s, and to avoid confusion with 403 PermissionDenied.