### PR TITLE
Fix: Don't allow a union variant called 'type'

### DIFF
--- a/changelog/@unreleased/pr-422.v2.yml
+++ b/changelog/@unreleased/pr-422.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Don't allow a union variant called `type` as we don't know how that
+    should be serialized.
+  links:
+  - https://github.com/palantir/conjure/pull/422

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/UnionDefinitionValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/UnionDefinitionValidator.java
@@ -74,13 +74,14 @@ public enum UnionDefinitionValidator implements ConjureValidator<UnionDefinition
         @Override
         public void validate(UnionDefinition definition) {
             definition.getUnion().stream().forEach(fieldDef -> {
-                        Preconditions.checkArgument(!Strings.isNullOrEmpty(fieldDef.getFieldName().get()),
-                                "Union member key must not be empty");
-                        Preconditions.checkArgument(isValidJavaIdentifier(fieldDef.getFieldName().get()),
-                                "Union member key must be a valid Java identifier: %s",
-                                fieldDef.getFieldName().get());
-                    }
-            );
+                Preconditions.checkArgument(!Strings.isNullOrEmpty(fieldDef.getFieldName().get()),
+                        "Union member key must not be empty");
+                Preconditions.checkArgument(isValidJavaIdentifier(fieldDef.getFieldName().get()),
+                        "Union member key must be a valid Java identifier: %s",
+                        fieldDef.getFieldName().get());
+                Preconditions.checkArgument(!fieldDef.getFieldName().get().equals("type"),
+                        "Union member key must not be 'type'");
+            });
         }
     }
 }

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/UnionDefinitionValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/UnionDefinitionValidator.java
@@ -23,7 +23,8 @@ import com.palantir.conjure.spec.UnionDefinition;
 @com.google.errorprone.annotations.Immutable
 public enum UnionDefinitionValidator implements ConjureValidator<UnionDefinition> {
     KEY_SYNTAX(new KeySyntaxValidator()),
-    NO_TRAILING_UNDERSCORE(new NoTrailingUnderscoreValidator());
+    NO_TRAILING_UNDERSCORE(new NoTrailingUnderscoreValidator()),
+    NO_CLOBBER_TYPE(new NoClobberTypeValidator());
 
     public static void validateAll(UnionDefinition definition) {
         for (UnionDefinitionValidator validator : values()) {
@@ -79,6 +80,16 @@ public enum UnionDefinitionValidator implements ConjureValidator<UnionDefinition
                 Preconditions.checkArgument(isValidJavaIdentifier(fieldDef.getFieldName().get()),
                         "Union member key must be a valid Java identifier: %s",
                         fieldDef.getFieldName().get());
+            });
+        }
+    }
+
+    @com.google.errorprone.annotations.Immutable
+    private static final class NoClobberTypeValidator implements ConjureValidator<UnionDefinition> {
+
+        @Override
+        public void validate(UnionDefinition definition) {
+            definition.getUnion().stream().forEach(fieldDef -> {
                 Preconditions.checkArgument(!fieldDef.getFieldName().get().equals("type"),
                         "Union member key must not be 'type'");
             });


### PR DESCRIPTION
## Before this PR

`type` was an acceptable union variant name, but we have no idea how to serialize it to JSON. We can't use `"type"` as that's already reserved for the chosen union variant name.

This edge case is not mentioned in [the yml definition spec](https://palantir.github.io/conjure/#/docs/spec/conjure_definitions?id=uniontypedefinition) nor in [the wire format](https://palantir.github.io/conjure/#/docs/spec/wire?id=_54-union-json-format).

## After this PR
==COMMIT_MSG==
Don't allow a union variant called `type` as we don't know how that should be serialized.
==COMMIT_MSG==

Fixes #179.

## Possible downsides?

People might have come up with a format for how to serialize this edge case in a particular generator only (e.g. go, rust?) that didn't make it back to the spec, in which case we'd break those use cases.