### PR TITLE
Fix #120: Enum values, fields, and union values support deprecation

### DIFF
--- a/changelog/@unreleased/pr-494.v2.yml
+++ b/changelog/@unreleased/pr-494.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Enum values, fields, and union values support deprecation documentation.
+  links:
+  - https://github.com/palantir/conjure/pull/494

--- a/conjure-api/src/main/conjure/conjure-api.yml
+++ b/conjure-api/src/main/conjure/conjure-api.yml
@@ -129,11 +129,13 @@ types:
         fields:
           value: string
           docs: optional<Documentation>
+          deprecated: optional<Documentation>
       FieldDefinition:
         fields:
           fieldName: FieldName
           type: Type
           docs: optional<Documentation>
+          deprecated: optional<Documentation>
       FieldName:
         alias: string
         docs: Should be in lowerCamelCase, but kebab-case and snake_case are also permitted.

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureParserUtils.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureParserUtils.java
@@ -303,6 +303,7 @@ public final class ConjureParserUtils {
         EnumValueDefinition enumValue = EnumValueDefinition.builder()
                 .value(def.value())
                 .docs(def.docs().map(Documentation::of))
+                .deprecated(def.deprecated().map(Documentation::of))
                 .build();
 
         EnumValueDefinitionValidator.validateAll(enumValue);
@@ -317,7 +318,9 @@ public final class ConjureParserUtils {
             FieldDefinition fieldDefinition = FieldDefinition.builder()
                     .fieldName(parseFieldName(entry.getKey()))
                     .type(entry.getValue().type().visit(new ConjureTypeParserVisitor(typeResolver)))
-                    .docs(entry.getValue().docs().map(Documentation::of)).build();
+                    .docs(entry.getValue().docs().map(Documentation::of))
+                    .deprecated(entry.getValue().deprecated().map(Documentation::of))
+                    .build();
             FieldDefinitionValidator.validate(fieldDefinition);
             return fieldDefinition;
         }).collect(Collectors.toList());

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/types/complex/EnumValueDefinition.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/types/complex/EnumValueDefinition.java
@@ -35,6 +35,8 @@ public interface EnumValueDefinition {
 
     Optional<String> docs();
 
+    Optional<String> deprecated();
+
     static EnumValueDefinition.Builder builder() {
         return new Builder();
     }

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/types/complex/FieldDefinition.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/types/complex/FieldDefinition.java
@@ -37,6 +37,8 @@ public interface FieldDefinition {
 
     Optional<String> docs();
 
+    Optional<String> deprecated();
+
     static FieldDefinition of(ConjureType type) {
         return ImmutableFieldDefinition.builder().type(type).build();
     }

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ConjureSourceFileValidatorTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ConjureSourceFileValidatorTest.java
@@ -55,7 +55,11 @@ public class ConjureSourceFileValidatorTest {
                 .types(ImmutableList.of(TypeDefinition.object(
                         ObjectDefinition.builder()
                                 .typeName(FOO)
-                                .fields(FieldDefinition.builder().fieldName(FieldName.of("self")).type(Type.reference(FOO)).docs(DOCS).build())
+                                .fields(FieldDefinition.builder()
+                                        .fieldName(FieldName.of("self"))
+                                        .type(Type.reference(FOO))
+                                        .docs(DOCS)
+                                        .build())
                                 .build())))
                 .build();
 
@@ -211,6 +215,10 @@ public class ConjureSourceFileValidatorTest {
     }
 
     private FieldDefinition field(FieldName name, String type) {
-        return FieldDefinition.builder().fieldName(name).type(Type.reference(TypeName.of(type, PACKAGE))).docs(DOCS).build();
+        return FieldDefinition.builder()
+                .fieldName(name)
+                .type(Type.reference(TypeName.of(type, PACKAGE)))
+                .docs(DOCS)
+                .build();
     }
 }

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ConjureSourceFileValidatorTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ConjureSourceFileValidatorTest.java
@@ -55,7 +55,7 @@ public class ConjureSourceFileValidatorTest {
                 .types(ImmutableList.of(TypeDefinition.object(
                         ObjectDefinition.builder()
                                 .typeName(FOO)
-                                .fields(FieldDefinition.of(FieldName.of("self"), Type.reference(FOO), DOCS))
+                                .fields(FieldDefinition.builder().fieldName(FieldName.of("self")).type(Type.reference(FOO)).docs(DOCS).build())
                                 .build())))
                 .build();
 
@@ -71,14 +71,14 @@ public class ConjureSourceFileValidatorTest {
                 ObjectDefinition.builder()
                         .typeName(TypeName.of("Foo", "bar"))
                         .addAllFields(ImmutableList.of(
-                                FieldDefinition.of(FieldName.of("selfOptional"),
-                                        Type.optional(OptionalType.of(Type.reference(FOO))), DOCS),
-                                FieldDefinition.of(FieldName.of("selfMap"),
-                                        Type.map(MapType.of(referenceType, referenceType)), DOCS),
-                                FieldDefinition.of(FieldName.of("selfSet"),
-                                        Type.set(SetType.of(referenceType)), DOCS),
-                                FieldDefinition.of(FieldName.of("selfList"),
-                                        Type.list(ListType.of(referenceType)), DOCS)))
+                                FieldDefinition.builder().fieldName(FieldName.of("selfOptional")).type(
+                                        Type.optional(OptionalType.of(Type.reference(FOO)))).docs(DOCS).build(),
+                                FieldDefinition.builder().fieldName(FieldName.of("selfMap"))
+                                        .type(Type.map(MapType.of(referenceType, referenceType))).docs(DOCS).build(),
+                                FieldDefinition.builder().fieldName(FieldName.of("selfSet"))
+                                        .type(Type.set(SetType.of(referenceType))).docs(DOCS).build(),
+                                FieldDefinition.builder().fieldName(FieldName.of("selfList"))
+                                        .type(Type.list(ListType.of(referenceType))).docs(DOCS).build()))
                         .build());
         ConjureDefinition conjureDef = ConjureDefinition.builder()
                 .version(1)
@@ -138,10 +138,10 @@ public class ConjureSourceFileValidatorTest {
                 .version(1)
                 .types(TypeDefinition.object(ObjectDefinition.builder()
                         .typeName(FOO)
-                        .fields(FieldDefinition.of(FieldName.of("bad"),
-                                Type.map(MapType.of(
+                        .fields(FieldDefinition.builder().fieldName(FieldName.of("bad"))
+                                .type(Type.map(MapType.of(
                                         Type.list(ListType.of(Type.primitive(PrimitiveType.STRING))),
-                                        Type.primitive(PrimitiveType.STRING))), DOCS))
+                                        Type.primitive(PrimitiveType.STRING)))).docs(DOCS).build())
                         .build()))
                 .build();
         assertThatThrownBy(() -> ConjureDefinitionValidator.ILLEGAL_MAP_KEYS.validate(conjureDef))
@@ -159,10 +159,10 @@ public class ConjureSourceFileValidatorTest {
                         .build()))
                 .types(TypeDefinition.object(ObjectDefinition.builder()
                         .typeName(FOO)
-                        .fields(FieldDefinition.of(FieldName.of("bad"),
-                                Type.map(MapType.of(
+                        .fields(FieldDefinition.builder().fieldName(FieldName.of("bad"))
+                                .type(Type.map(MapType.of(
                                         Type.list(ListType.of(Type.primitive(PrimitiveType.STRING))),
-                                        Type.primitive(PrimitiveType.STRING))), DOCS))
+                                        Type.primitive(PrimitiveType.STRING)))).docs(DOCS).build())
                         .build()))
                 .build();
         assertThatThrownBy(() -> ConjureDefinitionValidator.ILLEGAL_MAP_KEYS.validate(conjureDef))
@@ -176,13 +176,13 @@ public class ConjureSourceFileValidatorTest {
                 .version(1)
                 .types(TypeDefinition.object(ObjectDefinition.builder()
                         .typeName(FOO)
-                        .fields(FieldDefinition.of(FieldName.of("bad"),
-                                Type.map(MapType.of(
+                        .fields(FieldDefinition.builder().fieldName(FieldName.of("bad"))
+                                .type(Type.map(MapType.of(
                                         Type.external(ExternalReference.builder()
                                                 .externalReference(TypeName.of("Foo", "package"))
                                                 .fallback(Type.primitive(PrimitiveType.STRING))
                                                 .build()),
-                                        Type.primitive(PrimitiveType.STRING))), DOCS))
+                                        Type.primitive(PrimitiveType.STRING)))).docs(DOCS).build())
                         .build()))
                 .build();
         assertThatCode(() -> ConjureDefinitionValidator.ILLEGAL_MAP_KEYS.validate(conjureDef))
@@ -196,13 +196,13 @@ public class ConjureSourceFileValidatorTest {
                 .version(1)
                 .types(TypeDefinition.object(ObjectDefinition.builder()
                         .typeName(FOO)
-                        .fields(FieldDefinition.of(FieldName.of("bad"),
-                                Type.map(MapType.of(
+                        .fields(FieldDefinition.builder().fieldName(FieldName.of("bad"))
+                                .type(Type.map(MapType.of(
                                         Type.external(ExternalReference.builder()
                                                 .externalReference(TypeName.of("Foo", "package"))
                                                 .fallback(Type.primitive(PrimitiveType.ANY))
                                                 .build()),
-                                        Type.primitive(PrimitiveType.STRING))), DOCS))
+                                        Type.primitive(PrimitiveType.STRING)))).docs(DOCS).build())
                         .build()))
                 .build();
         assertThatThrownBy(() -> ConjureDefinitionValidator.ILLEGAL_MAP_KEYS.validate(conjureDef))
@@ -211,6 +211,6 @@ public class ConjureSourceFileValidatorTest {
     }
 
     private FieldDefinition field(FieldName name, String type) {
-        return FieldDefinition.of(name, Type.reference(TypeName.of(type, PACKAGE)), DOCS);
+        return FieldDefinition.builder().fieldName(name).type(Type.reference(TypeName.of(type, PACKAGE))).docs(DOCS).build();
     }
 }

--- a/conjure-core/src/test/java/com/palantir/conjure/parser/ConjureParserTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/parser/ConjureParserTest.java
@@ -21,9 +21,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableList;
+import com.palantir.conjure.parser.types.TypeDefinitionVisitor;
+import com.palantir.conjure.parser.types.complex.EnumTypeDefinition;
+import com.palantir.conjure.parser.types.complex.EnumValueDefinition;
+import com.palantir.conjure.parser.types.complex.ObjectTypeDefinition;
+import com.palantir.conjure.parser.types.complex.UnionTypeDefinition;
+import com.palantir.conjure.parser.types.names.FieldName;
 import com.palantir.conjure.parser.types.names.Namespace;
 import com.palantir.conjure.parser.types.names.TypeName;
 import com.palantir.conjure.parser.types.primitive.PrimitiveType;
+import com.palantir.conjure.parser.types.reference.AliasTypeDefinition;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -60,6 +68,105 @@ public class ConjureParserTest {
         ConjureSourceFile conjure = ConjureParser.parse(new File("src/test/resources/example-external-types.yml"));
         assertThat(conjure.types().imports().get(TypeName.of("ExampleAnyImport")).baseType())
                 .isEqualTo(PrimitiveType.fromString("any"));
+    }
+
+    @Test
+    public void testConjureFieldDeprecation() {
+        ConjureSourceFile conjure = ConjureParser.parse(new File("src/test/resources/example-deprecation.yml"));
+        ObjectTypeDefinition object = conjure.types()
+                .definitions()
+                .objects()
+                .get(TypeName.of("BeanWithDeprecatedField"))
+                .visit(new TypeDefinitionVisitor<ObjectTypeDefinition>() {
+                    @Override
+                    public ObjectTypeDefinition visit(AliasTypeDefinition def) {
+                        throw new SafeIllegalArgumentException("Expected ObjectTypeDefinition");
+                    }
+
+                    @Override
+                    public ObjectTypeDefinition visit(EnumTypeDefinition def) {
+                        throw new SafeIllegalArgumentException("Expected ObjectTypeDefinition");
+                    }
+
+                    @Override
+                    public ObjectTypeDefinition visit(ObjectTypeDefinition def) {
+                        return def;
+                    }
+
+                    @Override
+                    public ObjectTypeDefinition visit(UnionTypeDefinition def) {
+                        throw new SafeIllegalArgumentException("Expected ObjectTypeDefinition");
+                    }
+                });
+        assertThat(object.fields().get(FieldName.of("old")).deprecated()).hasValue("Test deprecated.");
+    }
+
+    @Test
+    public void testConjureEnumValueDeprecation() {
+        ConjureSourceFile conjure = ConjureParser.parse(new File("src/test/resources/example-deprecation.yml"));
+        EnumTypeDefinition enumType = conjure.types()
+                .definitions()
+                .objects()
+                .get(TypeName.of("EnumWithDeprecatedValues"))
+                .visit(new TypeDefinitionVisitor<EnumTypeDefinition>() {
+                    @Override
+                    public EnumTypeDefinition visit(AliasTypeDefinition def) {
+                        throw new SafeIllegalArgumentException("Expected EnumTypeDefinition");
+                    }
+
+                    @Override
+                    public EnumTypeDefinition visit(EnumTypeDefinition def) {
+                        return def;
+                    }
+
+                    @Override
+                    public EnumTypeDefinition visit(ObjectTypeDefinition def) {
+                        throw new SafeIllegalArgumentException("Expected EnumTypeDefinition");
+                    }
+
+                    @Override
+                    public EnumTypeDefinition visit(UnionTypeDefinition def) {
+                        throw new SafeIllegalArgumentException("Expected EnumTypeDefinition");
+                    }
+                });
+        EnumValueDefinition one = enumType.values().get(0);
+        EnumValueDefinition two = enumType.values().get(1);
+        assertThat(one.value()).isEqualTo("ONE");
+        assertThat(one.deprecated()).isNotPresent();
+        assertThat(two.value()).isEqualTo("TWO");
+        assertThat(two.deprecated()).hasValue("Prefer ONE.");
+    }
+
+    @Test
+    public void testConjureUnionTypeDeprecation() {
+        ConjureSourceFile conjure = ConjureParser.parse(new File("src/test/resources/example-deprecation.yml"));
+        UnionTypeDefinition union = conjure.types()
+                .definitions()
+                .objects()
+                .get(TypeName.of("UnionWithDeprecatedTypes"))
+                .visit(new TypeDefinitionVisitor<UnionTypeDefinition>() {
+                    @Override
+                    public UnionTypeDefinition visit(AliasTypeDefinition def) {
+                        throw new SafeIllegalArgumentException("Expected EnumTypeDefinition");
+                    }
+
+                    @Override
+                    public UnionTypeDefinition visit(EnumTypeDefinition def) {
+                        throw new SafeIllegalArgumentException("Expected EnumTypeDefinition");
+                    }
+
+                    @Override
+                    public UnionTypeDefinition visit(ObjectTypeDefinition def) {
+                        throw new SafeIllegalArgumentException("Expected EnumTypeDefinition");
+                    }
+
+                    @Override
+                    public UnionTypeDefinition visit(UnionTypeDefinition def) {
+                        return def;
+                    }
+                });
+        assertThat(union.union().get(FieldName.of("first")).deprecated()).isNotPresent();
+        assertThat(union.union().get(FieldName.of("second")).deprecated()).hasValue("Use 'first'.");
     }
 
     @Test

--- a/conjure-core/src/test/java/com/palantir/conjure/parser/ConjureParserTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/parser/ConjureParserTest.java
@@ -79,12 +79,12 @@ public class ConjureParserTest {
                 .get(TypeName.of("BeanWithDeprecatedField"))
                 .visit(new TypeDefinitionVisitor<ObjectTypeDefinition>() {
                     @Override
-                    public ObjectTypeDefinition visit(AliasTypeDefinition def) {
+                    public ObjectTypeDefinition visit(AliasTypeDefinition _def) {
                         throw new SafeIllegalArgumentException("Expected ObjectTypeDefinition");
                     }
 
                     @Override
-                    public ObjectTypeDefinition visit(EnumTypeDefinition def) {
+                    public ObjectTypeDefinition visit(EnumTypeDefinition _def) {
                         throw new SafeIllegalArgumentException("Expected ObjectTypeDefinition");
                     }
 
@@ -94,7 +94,7 @@ public class ConjureParserTest {
                     }
 
                     @Override
-                    public ObjectTypeDefinition visit(UnionTypeDefinition def) {
+                    public ObjectTypeDefinition visit(UnionTypeDefinition _def) {
                         throw new SafeIllegalArgumentException("Expected ObjectTypeDefinition");
                     }
                 });
@@ -110,7 +110,7 @@ public class ConjureParserTest {
                 .get(TypeName.of("EnumWithDeprecatedValues"))
                 .visit(new TypeDefinitionVisitor<EnumTypeDefinition>() {
                     @Override
-                    public EnumTypeDefinition visit(AliasTypeDefinition def) {
+                    public EnumTypeDefinition visit(AliasTypeDefinition _def) {
                         throw new SafeIllegalArgumentException("Expected EnumTypeDefinition");
                     }
 
@@ -120,12 +120,12 @@ public class ConjureParserTest {
                     }
 
                     @Override
-                    public EnumTypeDefinition visit(ObjectTypeDefinition def) {
+                    public EnumTypeDefinition visit(ObjectTypeDefinition _def) {
                         throw new SafeIllegalArgumentException("Expected EnumTypeDefinition");
                     }
 
                     @Override
-                    public EnumTypeDefinition visit(UnionTypeDefinition def) {
+                    public EnumTypeDefinition visit(UnionTypeDefinition _def) {
                         throw new SafeIllegalArgumentException("Expected EnumTypeDefinition");
                     }
                 });
@@ -146,17 +146,17 @@ public class ConjureParserTest {
                 .get(TypeName.of("UnionWithDeprecatedTypes"))
                 .visit(new TypeDefinitionVisitor<UnionTypeDefinition>() {
                     @Override
-                    public UnionTypeDefinition visit(AliasTypeDefinition def) {
+                    public UnionTypeDefinition visit(AliasTypeDefinition _def) {
                         throw new SafeIllegalArgumentException("Expected EnumTypeDefinition");
                     }
 
                     @Override
-                    public UnionTypeDefinition visit(EnumTypeDefinition def) {
+                    public UnionTypeDefinition visit(EnumTypeDefinition _def) {
                         throw new SafeIllegalArgumentException("Expected EnumTypeDefinition");
                     }
 
                     @Override
-                    public UnionTypeDefinition visit(ObjectTypeDefinition def) {
+                    public UnionTypeDefinition visit(ObjectTypeDefinition _def) {
                         throw new SafeIllegalArgumentException("Expected EnumTypeDefinition");
                     }
 

--- a/conjure-core/src/test/java/com/palantir/conjure/validator/FieldDefinitionValidatorTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/validator/FieldDefinitionValidatorTest.java
@@ -34,10 +34,10 @@ public class FieldDefinitionValidatorTest {
     public void testNoComplexKeysInMaps() {
         String illegalFieldName = "asdf";
         Type complexKeyType = Type.list(ListType.of(Type.primitive(PrimitiveType.STRING)));
-        FieldDefinition fieldDefinition = FieldDefinition.of(
-                FieldName.of(illegalFieldName),
-                Type.map(MapType.of(complexKeyType, Type.primitive(PrimitiveType.STRING))),
-                Documentation.of("docs"));
+        FieldDefinition fieldDefinition = FieldDefinition.builder().fieldName(
+                FieldName.of(illegalFieldName))
+                .type(Type.map(MapType.of(complexKeyType, Type.primitive(PrimitiveType.STRING))))
+                .docs(Documentation.of("docs")).build();
         assertThatThrownBy(() -> FieldDefinitionValidator.validate(fieldDefinition))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining(illegalFieldName)

--- a/conjure-core/src/test/resources/example-deprecation.yml
+++ b/conjure-core/src/test/resources/example-deprecation.yml
@@ -1,0 +1,21 @@
+types:
+  definitions:
+    default-package: com.palantir.deprecation
+    objects:
+      BeanWithDeprecatedField:
+        fields:
+          id: rid
+          old:
+            type: string
+            deprecated: Test deprecated.
+      EnumWithDeprecatedValues:
+        values:
+          - ONE
+          - value: TWO
+            deprecated: Prefer ONE.
+      UnionWithDeprecatedTypes:
+        union:
+          first: string
+          second:
+            type: string
+            deprecated: Use 'first'.

--- a/conjure-core/src/test/resources/normalized.conjure.json
+++ b/conjure-core/src/test/resources/normalized.conjure.json
@@ -14,7 +14,8 @@
         "type" : "primitive",
         "primitive" : "INTEGER"
       },
-      "docs" : null
+      "docs" : null,
+      "deprecated" : null
     } ],
     "unsafeArgs" : [ ]
   }, {
@@ -31,7 +32,8 @@
         "type" : "primitive",
         "primitive" : "INTEGER"
       },
-      "docs" : null
+      "docs" : null,
+      "deprecated" : null
     } ],
     "unsafeArgs" : [ ]
   } ],
@@ -48,7 +50,8 @@
           "type" : "primitive",
           "primitive" : "STRING"
         },
-        "docs" : null
+        "docs" : null,
+        "deprecated" : null
       } ],
       "docs" : null
     }

--- a/docs/spec/conjure_definitions.md
+++ b/docs/spec/conjure_definitions.md
@@ -209,6 +209,7 @@ Field | Type | Description
 ---|:---:|---
 type | [ConjureType][] | **REQUIRED**. The name of the type of the field. It MUST be a type name that exists within the Conjure definition.
 docs | [DocString][] | Documentation for the type. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
+deprecated | [DocString][] | Documentation for why this field is deprecated. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 
 
 ## UnionTypeDefinition
@@ -219,6 +220,7 @@ Field | Type | Description
 ---------- | ---- | -----------
 union | Map[`string` &rarr; [FieldDefinition][] or [ConjureType][]] | **REQUIRED**. A map from union names to type names. If the value of the field is a `string` it MUST be a type name that exists within the Conjure definition. Union names MUST be in PascalCase.
 docs | [DocString][] | Documentation for the type. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
+deprecated | [DocString][] | Documentation for why this value is deprecated. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 package | `string` | **REQUIRED** if `default-package` is not specified. Overrides the `default-package` in [NamedTypesDefinition][].
 
 It is common for a generator to also generate a visitor interface for each union, to facilitate consumption and customization of behavior depending on the wrapped type. The interface includes a visit() method for each wrapped type, as well as a visitUnknown(String unknownType) method which is executed when the wrapped object does not match any of the known member types.
@@ -241,6 +243,7 @@ Field | Type | Description
 ---|:---:|---
 values | List[string or [EnumValueDefinition][]] | **REQUIRED**. A list of enumeration values. All elements in the list MUST be unique and be UPPERCASE.
 docs | [DocString][] | Documentation for the type. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
+deprecated | [DocString][] | Documentation for why this value is deprecated. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 package | `string` | **REQUIRED** if `default-package` is not specified. Overrides the `default-package` in [NamedTypesDefinition][].
 
 **Example:**

--- a/docs/spec/intermediate_representation.md
+++ b/docs/spec/intermediate_representation.md
@@ -70,7 +70,8 @@ Example alias definition:
 An enum definition must have a "typeName" key describing the package and name of the type. It must also have a "values"
 key referring to a list of possible values for the enum. Each item in the list must have a "value" key
 corresponding to the string representation of the value. Each item in the list may have a "docs" key containing
-string documentation for the enum value.
+string documentation for the enum value. Each item in the list may have a "deprecated" key containing string
+documentation for why the enum value is deprecated.
 
 An enum definition may have a "docs" key containing string documentation for the enum type.
 
@@ -106,7 +107,8 @@ An object definition must have a "typeName" key describing the package and name 
 "fields" key referring to a list of field definitions. Each field definition must have a "fieldName" key with a string
 value, and a "type" key with a value that is a representation of the field type (see
 [Representation of Conjure Types](#representation-of-conjure-types)). Each field definition may have a "docs" key
-containing string documentation for the field.
+containing string documentation for the field. Each field in the list may have a "deprecated" key containing string
+documentation for why the field is deprecated.
 
 An object definition may have a "docs" key containing string documentation for the object.
 


### PR DESCRIPTION
## Before this PR
No deprecation docs on fields, union types, or enum values.

## After this PR
==COMMIT_MSG==
 Enum values, fields, and union values support deprecation documentation.
==COMMIT_MSG==

## Possible downsides?

This is an additive change to the intermediate representation,
however there is little risk for consumers because this information
is simple metadata.

