### PR TITLE
Fix #491: Validate against binary data in non-body container parameters

### DIFF
--- a/changelog/@unreleased/pr-497.v2.yml
+++ b/changelog/@unreleased/pr-497.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Validate against binary data in non-body container parameters.
+  links:
+  - https://github.com/palantir/conjure/pull/497

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/EndpointDefinitionValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/EndpointDefinitionValidator.java
@@ -100,12 +100,10 @@ public enum EndpointDefinitionValidator implements ConjureContextualValidator<En
             definition.getArgs()
                     .stream()
                     .filter(arg -> !arg.getParamType().accept(ParameterTypeVisitor.IS_BODY))
-                    .forEach(arg -> {
-                        Preconditions.checkArgument(
-                                validateType(arg.getType(), dealiasingTypeVisitor),
-                                "Non body parameters cannot be of the 'binary' type: '%s' is not allowed",
-                                arg.getArgName());
-                    });
+                    .forEach(arg -> Preconditions.checkArgument(
+                            validateType(arg.getType(), dealiasingTypeVisitor),
+                            "Non body parameters cannot be of the 'binary' type: '%s' is not allowed",
+                            arg.getArgName()));
         }
 
         private static boolean validateType(Type input, DealiasingTypeVisitor dealiasingTypeVisitor) {
@@ -347,20 +345,32 @@ public enum EndpointDefinitionValidator implements ConjureContextualValidator<En
             definition.getArgs().stream()
                     .filter(entry -> entry.getParamType().accept(ParameterTypeVisitor.IS_PATH)
                             || entry.getParamType().accept(ParameterTypeVisitor.IS_QUERY))
-                    .forEach(entry -> {
-                        Either<TypeDefinition, Type> conjureType = dealiasingTypeVisitor.dealias(entry.getType());
-                        boolean isValid = conjureType.fold(
-                                typeDefinition -> true,
-                                type -> !type.accept(TypeVisitor.IS_PRIMITIVE)
-                                        || type.accept(TypeVisitor.PRIMITIVE).get() != PrimitiveType.Value.BEARERTOKEN
-                        );
+                    .forEach(entry -> Preconditions.checkState(
+                            validateType(entry.getType(), dealiasingTypeVisitor),
+                            "Path or query parameters of type 'bearertoken' are not allowed as this "
+                                    + "would introduce a security vulnerability: \"%s\" endpoint \"%s\"",
+                            entry.getArgName(), describe(definition)));
+        }
 
-                        Preconditions.checkState(
-                                isValid,
-                                "Path or query parameters of type 'bearertoken' are not allowed as this "
-                                        + "would introduce a security vulnerability: \"%s\" endpoint \"%s\"",
-                                entry.getArgName(), describe(definition));
-                    });
+        private static boolean validateType(Type input, DealiasingTypeVisitor dealiasingTypeVisitor) {
+            Optional<Type> dealiased = dealiasingTypeVisitor.dealias(input)
+                    .fold(typeDefinition -> Optional.empty(), Optional::of);
+            // typeDef isn't bearertoken
+            if (!dealiased.isPresent()) {
+                return true;
+            }
+            Type type = dealiased.get();
+            if (input.accept(TypeVisitor.IS_OPTIONAL)) {
+                return validateType(input.accept(TypeVisitor.OPTIONAL).getItemType(), dealiasingTypeVisitor);
+            }
+            if (input.accept(TypeVisitor.IS_LIST)) {
+                return validateType(input.accept(TypeVisitor.LIST).getItemType(), dealiasingTypeVisitor);
+            }
+            if (input.accept(TypeVisitor.IS_SET)) {
+                return validateType(input.accept(TypeVisitor.SET).getItemType(), dealiasingTypeVisitor);
+            }
+            return !type.accept(TypeVisitor.IS_PRIMITIVE)
+                    || type.accept(TypeVisitor.PRIMITIVE).get() != PrimitiveType.Value.BEARERTOKEN;
         }
     }
 

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/EndpointDefinitionValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/EndpointDefinitionValidator.java
@@ -43,6 +43,7 @@ import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -100,16 +101,31 @@ public enum EndpointDefinitionValidator implements ConjureContextualValidator<En
                     .stream()
                     .filter(arg -> !arg.getParamType().accept(ParameterTypeVisitor.IS_BODY))
                     .forEach(arg -> {
-                        boolean isValid = dealiasingTypeVisitor.dealias(arg.getType())
-                                .fold(
-                                        typeDefinition -> true,
-                                        type -> !type.accept(TypeVisitor.IS_BINARY)
-                                                && !type.accept(TypeVisitor.IS_ANY)
-                                );
                         Preconditions.checkArgument(
-                                isValid, "Non body parameters cannot be of the 'binary' type: '%s' is not allowed",
+                                validateType(arg.getType(), dealiasingTypeVisitor),
+                                "Non body parameters cannot be of the 'binary' type: '%s' is not allowed",
                                 arg.getArgName());
                     });
+        }
+
+        private static boolean validateType(Type input, DealiasingTypeVisitor dealiasingTypeVisitor) {
+            Optional<Type> dealiased = dealiasingTypeVisitor.dealias(input)
+                    .fold(typeDefinition -> Optional.empty(), Optional::of);
+            // typeDef isn't binary
+            if (!dealiased.isPresent()) {
+                return true;
+            }
+            Type type = dealiased.get();
+            if (input.accept(TypeVisitor.IS_OPTIONAL)) {
+                return validateType(input.accept(TypeVisitor.OPTIONAL).getItemType(), dealiasingTypeVisitor);
+            }
+            if (input.accept(TypeVisitor.IS_LIST)) {
+                return validateType(input.accept(TypeVisitor.LIST).getItemType(), dealiasingTypeVisitor);
+            }
+            if (input.accept(TypeVisitor.IS_SET)) {
+                return validateType(input.accept(TypeVisitor.SET).getItemType(), dealiasingTypeVisitor);
+            }
+            return !type.accept(TypeVisitor.IS_BINARY) && !type.accept(TypeVisitor.IS_ANY);
         }
     }
 

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/EndpointDefinitionValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/EndpointDefinitionValidator.java
@@ -102,8 +102,10 @@ public enum EndpointDefinitionValidator implements ConjureContextualValidator<En
                     .filter(arg -> !arg.getParamType().accept(ParameterTypeVisitor.IS_BODY))
                     .forEach(arg -> Preconditions.checkArgument(
                             validateType(arg.getType(), dealiasingTypeVisitor),
-                            "Non body parameters cannot be of the 'binary' type: '%s' is not allowed",
-                            arg.getArgName()));
+                            "Non body parameters cannot contain the 'binary' type. "
+                                    + "Parameter '%s' from endpoint '%s' violates this constraint.",
+                            arg.getArgName(),
+                            describe(definition)));
         }
 
         private static boolean validateType(Type input, DealiasingTypeVisitor dealiasingTypeVisitor) {

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/validator/EndpointDefinitionTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/validator/EndpointDefinitionTest.java
@@ -68,7 +68,8 @@ public final class EndpointDefinitionTest {
 
         assertThatThrownBy(() -> EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Non body parameters cannot contain the 'binary' type. Parameter 'testArg' from endpoint 'test{http: GET /a/path}' violates this constraint.");
+                .hasMessage("Non body parameters cannot contain the 'binary' type. Parameter 'testArg' "
+                        + "from endpoint 'test{http: GET /a/path}' violates this constraint.");
     }
 
     @Test
@@ -183,7 +184,8 @@ public final class EndpointDefinitionTest {
 
         assertThatThrownBy(() -> EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Non body parameters cannot contain the 'binary' type. Parameter 'paramName' from endpoint 'test{http: GET /path}' violates this constraint.");
+                .hasMessage("Non body parameters cannot contain the 'binary' type. Parameter 'paramName' "
+                        + "from endpoint 'test{http: GET /path}' violates this constraint.");
     }
 
     @Test
@@ -217,7 +219,8 @@ public final class EndpointDefinitionTest {
 
         assertThatThrownBy(() -> EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Non body parameters cannot contain the 'binary' type. Parameter 'paramName' from endpoint 'test{http: GET /path}' violates this constraint.");
+                .hasMessage("Non body parameters cannot contain the 'binary' type. Parameter 'paramName' "
+                        + "from endpoint 'test{http: GET /path}' violates this constraint.");
     }
 
     @Test
@@ -234,7 +237,8 @@ public final class EndpointDefinitionTest {
 
         assertThatThrownBy(() -> EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Non body parameters cannot contain the 'binary' type. Parameter 'paramName' from endpoint 'test{http: GET /path}' violates this constraint.");
+                .hasMessage("Non body parameters cannot contain the 'binary' type. Parameter 'paramName' "
+                        + "from endpoint 'test{http: GET /path}' violates this constraint.");
     }
 
     @Test

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/validator/EndpointDefinitionTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/validator/EndpointDefinitionTest.java
@@ -37,6 +37,8 @@ import com.palantir.conjure.spec.ParameterId;
 import com.palantir.conjure.spec.ParameterType;
 import com.palantir.conjure.spec.PathParameterType;
 import com.palantir.conjure.spec.PrimitiveType;
+import com.palantir.conjure.spec.QueryParameterType;
+import com.palantir.conjure.spec.SetType;
 import com.palantir.conjure.spec.Type;
 import com.palantir.conjure.spec.TypeDefinition;
 import com.palantir.conjure.spec.TypeName;
@@ -165,6 +167,57 @@ public final class EndpointDefinitionTest {
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("Path parameter with identifier \"paramName\" is "
                         + "defined multiple times for endpoint test{http: GET /a/path}");
+    }
+
+    @Test
+    public void testQueryParamValidatorBinaryParamInContainer_list() {
+        EndpointDefinition.Builder definition = EndpointDefinition.builder()
+                .args(ImmutableList.of(ArgumentDefinition.builder()
+                        .argName(ArgumentName.of("paramName"))
+                        .type(Type.list(ListType.of(Type.primitive(PrimitiveType.BINARY))))
+                        .paramType(ParameterType.query(QueryParameterType.of(ParameterId.of("value"))))
+                        .build()))
+                .endpointName(ENDPOINT_NAME)
+                .httpMethod(HttpMethod.GET)
+                .httpPath(HttpPath.of("/path"));
+
+        assertThatThrownBy(() -> EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Non body parameters cannot be of the 'binary' type: 'paramName' is not allowed");
+    }
+
+    @Test
+    public void testQueryParamValidatorBinaryParamInContainer_set() {
+        EndpointDefinition.Builder definition = EndpointDefinition.builder()
+                .args(ImmutableList.of(ArgumentDefinition.builder()
+                        .argName(ArgumentName.of("paramName"))
+                        .type(Type.set(SetType.of(Type.primitive(PrimitiveType.BINARY))))
+                        .paramType(ParameterType.query(QueryParameterType.of(ParameterId.of("value"))))
+                        .build()))
+                .endpointName(ENDPOINT_NAME)
+                .httpMethod(HttpMethod.GET)
+                .httpPath(HttpPath.of("/path"));
+
+        assertThatThrownBy(() -> EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Non body parameters cannot be of the 'binary' type: 'paramName' is not allowed");
+    }
+
+    @Test
+    public void testQueryParamValidatorBinaryParamInContainer_optional() {
+        EndpointDefinition.Builder definition = EndpointDefinition.builder()
+                .args(ImmutableList.of(ArgumentDefinition.builder()
+                        .argName(ArgumentName.of("paramName"))
+                        .type(Type.optional(OptionalType.of(Type.primitive(PrimitiveType.BINARY))))
+                        .paramType(ParameterType.query(QueryParameterType.of(ParameterId.of("value"))))
+                        .build()))
+                .endpointName(ENDPOINT_NAME)
+                .httpMethod(HttpMethod.GET)
+                .httpPath(HttpPath.of("/path"));
+
+        assertThatThrownBy(() -> EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Non body parameters cannot be of the 'binary' type: 'paramName' is not allowed");
     }
 
     @Test

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/validator/EndpointDefinitionTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/validator/EndpointDefinitionTest.java
@@ -187,6 +187,23 @@ public final class EndpointDefinitionTest {
     }
 
     @Test
+    public void testQueryParamValidatorBearerTokenParamInContainer() {
+        EndpointDefinition.Builder definition = EndpointDefinition.builder()
+                .args(ImmutableList.of(ArgumentDefinition.builder()
+                        .argName(ArgumentName.of("paramName"))
+                        .type(Type.list(ListType.of(Type.primitive(PrimitiveType.BEARERTOKEN))))
+                        .paramType(ParameterType.query(QueryParameterType.of(ParameterId.of("value"))))
+                        .build()))
+                .endpointName(ENDPOINT_NAME)
+                .httpMethod(HttpMethod.GET)
+                .httpPath(HttpPath.of("/path"));
+
+        assertThatThrownBy(() -> EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Path or query parameters of type 'bearertoken' are not allowed");
+    }
+
+    @Test
     public void testQueryParamValidatorBinaryParamInContainer_set() {
         EndpointDefinition.Builder definition = EndpointDefinition.builder()
                 .args(ImmutableList.of(ArgumentDefinition.builder()

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/validator/EndpointDefinitionTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/validator/EndpointDefinitionTest.java
@@ -68,7 +68,7 @@ public final class EndpointDefinitionTest {
 
         assertThatThrownBy(() -> EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Non body parameters cannot be of the 'binary' type: 'testArg' is not allowed");
+                .hasMessage("Non body parameters cannot contain the 'binary' type. Parameter 'testArg' from endpoint 'test{http: GET /a/path}' violates this constraint.");
     }
 
     @Test
@@ -183,7 +183,7 @@ public final class EndpointDefinitionTest {
 
         assertThatThrownBy(() -> EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Non body parameters cannot be of the 'binary' type: 'paramName' is not allowed");
+                .hasMessage("Non body parameters cannot contain the 'binary' type. Parameter 'paramName' from endpoint 'test{http: GET /path}' violates this constraint.");
     }
 
     @Test
@@ -217,7 +217,7 @@ public final class EndpointDefinitionTest {
 
         assertThatThrownBy(() -> EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Non body parameters cannot be of the 'binary' type: 'paramName' is not allowed");
+                .hasMessage("Non body parameters cannot contain the 'binary' type. Parameter 'paramName' from endpoint 'test{http: GET /path}' violates this constraint.");
     }
 
     @Test
@@ -234,7 +234,7 @@ public final class EndpointDefinitionTest {
 
         assertThatThrownBy(() -> EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Non body parameters cannot be of the 'binary' type: 'paramName' is not allowed");
+                .hasMessage("Non body parameters cannot contain the 'binary' type. Parameter 'paramName' from endpoint 'test{http: GET /path}' violates this constraint.");
     }
 
     @Test

--- a/conjure-core/src/test/resources/spec-tests/services.yml
+++ b/conjure-core/src/test/resources/spec-tests/services.yml
@@ -282,7 +282,7 @@ negative:
                   type: bearertoken
                   param-type: query
   disallowAnyInPathParams:
-    expected-error: "Non body parameters cannot be of the 'binary' type: 'foo' is not allowed"
+    expected-error: "Non body parameters cannot contain the 'binary' type. Parameter 'foo' from endpoint 'unused{http: GET /{foo}}' violates this constraint."
     conjure:
       services:
         Unused:
@@ -294,7 +294,7 @@ negative:
               args:
                 foo: any
   disallowAliasedAnyInPathParams:
-    expected-error: "Non body parameters cannot be of the 'binary' type: 'foo' is not allowed"
+    expected-error: "Non body parameters cannot contain the 'binary' type. Parameter 'foo' from endpoint 'unused{http: GET /{foo}}' violates this constraint."
     conjure:
       types:
         definitions:
@@ -412,7 +412,7 @@ negative:
                     type: optional<optional<string>>
                     param-type: query
   disallowQueryParamWithBinary:
-    expected-error: "Non body parameters cannot be of the 'binary' type: 'queryName' is not allowed"
+    expected-error: "Non body parameters cannot contain the 'binary' type. Parameter 'queryName' from endpoint 'testEndpoint{http: GET /myEndpoint}' violates this constraint."
     conjure:
       services:
         TestService:
@@ -426,7 +426,7 @@ negative:
                   type: binary
                   param-type: query
   disallowQueryParamWithAliasedBinary:
-    expected-error: "Non body parameters cannot be of the 'binary' type: 'queryName' is not allowed"
+    expected-error: "Non body parameters cannot contain the 'binary' type. Parameter 'queryName' from endpoint 'testEndpoint{http: GET /myEndpoint}' violates this constraint."
     conjure:
       types:
         definitions:


### PR DESCRIPTION
## Before this PR
Query and header parameters using `list<binary>` `set<binary>` and `optional<binary>` types incorrectly passed validation.

## After this PR
==COMMIT_MSG==
Validate against binary data in non-body container parameters.
==COMMIT_MSG==

