### PR TITLE
Fix deprecated docs

### DIFF
--- a/docs/spec/conjure_definitions.md
+++ b/docs/spec/conjure_definitions.md
@@ -220,7 +220,6 @@ Field | Type | Description
 ---------- | ---- | -----------
 union | Map[`string` &rarr; [FieldDefinition][] or [ConjureType][]] | **REQUIRED**. A map from union names to type names. If the value of the field is a `string` it MUST be a type name that exists within the Conjure definition. Union names MUST be in PascalCase.
 docs | [DocString][] | Documentation for the type. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
-deprecated | [DocString][] | Documentation for why this value is deprecated. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 package | `string` | **REQUIRED** if `default-package` is not specified. Overrides the `default-package` in [NamedTypesDefinition][].
 
 It is common for a generator to also generate a visitor interface for each union, to facilitate consumption and customization of behavior depending on the wrapped type. The interface includes a visit() method for each wrapped type, as well as a visitUnknown(String unknownType) method which is executed when the wrapped object does not match any of the known member types.
@@ -243,7 +242,6 @@ Field | Type | Description
 ---|:---:|---
 values | List[string or [EnumValueDefinition][]] | **REQUIRED**. A list of enumeration values. All elements in the list MUST be unique and be UPPERCASE.
 docs | [DocString][] | Documentation for the type. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
-deprecated | [DocString][] | Documentation for why this value is deprecated. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 package | `string` | **REQUIRED** if `default-package` is not specified. Overrides the `default-package` in [NamedTypesDefinition][].
 
 **Example:**
@@ -263,7 +261,7 @@ Field | Type | Description
 ---|:---:|---
 value | string | **REQUIRED**. The enumeration value. Value MUST be unique and be UPPERCASE.
 docs | [DocString][] | Documentation for the type. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
-
+deprecated | [DocString][] | Documentation for why this value is deprecated. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 
 ## ErrorDefinition
 [ErrorDefinition]: #errordefinition


### PR DESCRIPTION
Deprecation applies to union and enum variants, not the top-level types.