### PR TITLE
Conjure CLI is permissive with unknown options

### DIFF
--- a/changelog/@unreleased/pr-533.v2.yml
+++ b/changelog/@unreleased/pr-533.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Conjure CLI will log and ignore any unknown options that are provided
+  links:
+  - https://github.com/palantir/conjure/pull/533

--- a/conjure/src/main/java/com/palantir/conjure/cli/ConjureCli.java
+++ b/conjure/src/main/java/com/palantir/conjure/cli/ConjureCli.java
@@ -22,12 +22,9 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.annotations.VisibleForTesting;
 import com.palantir.conjure.defs.Conjure;
 import com.palantir.conjure.spec.ConjureDefinition;
-import com.palantir.logsafe.SafeArg;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
 @CommandLine.Command(
@@ -54,8 +51,6 @@ public final class ConjureCli implements Runnable {
             mixinStandardHelpOptions = true,
             usageHelpWidth = 120)
     public static final class CompileCommand implements Runnable {
-        private static final Logger log = LoggerFactory.getLogger(CompileCommand.class);
-
         @CommandLine.Parameters(paramLabel = "<input>",
                 description = "Path to the input conjure YML definition file, or directory containing multiple such "
                         + "files.",
@@ -71,10 +66,11 @@ public final class ConjureCli implements Runnable {
         @Nullable
         private List<String> unmatchedOptions;
 
+        @SuppressWarnings("BanSystemErr")
         @Override
         public void run() {
             if (unmatchedOptions != null && !unmatchedOptions.isEmpty()) {
-                log.warn("Ignoring unknown options", SafeArg.of("unknown options", unmatchedOptions));
+                System.err.println("Ignoring unknown options: " + unmatchedOptions);
             }
             CliConfiguration config = getConfiguration();
             generate(config);

--- a/conjure/src/main/java/com/palantir/conjure/cli/ConjureCli.java
+++ b/conjure/src/main/java/com/palantir/conjure/cli/ConjureCli.java
@@ -22,7 +22,12 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.annotations.VisibleForTesting;
 import com.palantir.conjure.defs.Conjure;
 import com.palantir.conjure.spec.ConjureDefinition;
+import com.palantir.logsafe.SafeArg;
 import java.io.IOException;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
 @CommandLine.Command(
@@ -49,6 +54,8 @@ public final class ConjureCli implements Runnable {
             mixinStandardHelpOptions = true,
             usageHelpWidth = 120)
     public static final class CompileCommand implements Runnable {
+        private static final Logger log = LoggerFactory.getLogger(CompileCommand.class);
+
         @CommandLine.Parameters(paramLabel = "<input>",
                 description = "Path to the input conjure YML definition file, or directory containing multiple such "
                         + "files.",
@@ -60,8 +67,15 @@ public final class ConjureCli implements Runnable {
                 index = "1")
         private String output;
 
+        @CommandLine.Unmatched
+        @Nullable
+        private List<String> unmatchedOptions;
+
         @Override
         public void run() {
+            if (unmatchedOptions != null && !unmatchedOptions.isEmpty()) {
+                log.warn("Ignoring unknown options", SafeArg.of("unknown options", unmatchedOptions));
+            }
             CliConfiguration config = getConfiguration();
             generate(config);
         }

--- a/conjure/src/test/java/com/palantir/conjure/cli/ConjureCliTest.java
+++ b/conjure/src/test/java/com/palantir/conjure/cli/ConjureCliTest.java
@@ -87,16 +87,14 @@ public final class ConjureCliTest {
     }
 
     @Test
-    public void throwsWhenUnexpectedFeature() {
+    public void doesNotThrowWhenUnexpectedFeature() {
         String[] args = {
                 "compile",
                 inputFile.getAbsolutePath(),
                 folder.getRoot().getAbsolutePath(),
                 "--foo"
         };
-        assertThatThrownBy(() -> CommandLine.populateCommand(new ConjureCli(), args))
-                .isInstanceOf(PicocliException.class)
-                .hasMessageContaining("Unknown option: --foo");
+        CommandLine.populateCommand(new ConjureCli(), args);
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
Conjure CLI would barf if any unknown options were provided. This made adding a new option require a lockstep upgrade between the CLI and the build tooling that would populate the option

## After this PR
==COMMIT_MSG==
Conjure CLI will log and ignore any unknown options that are provided
==COMMIT_MSG==

## Possible downsides?
N/A

