### PR TITLE
Better error message telling you which file the error came from

### DIFF
--- a/changelog/@unreleased/pr-537.v2.yml
+++ b/changelog/@unreleased/pr-537.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Errors encountered when parsing or validating conjure definition files
+    will now tell you which file the error was found in.
+  links:
+  - https://github.com/palantir/conjure/pull/537

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/Conjure.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/Conjure.java
@@ -16,8 +16,8 @@
 
 package com.palantir.conjure.defs;
 
+import com.palantir.conjure.parser.AnnotatedConjureSourceFile;
 import com.palantir.conjure.parser.ConjureParser;
-import com.palantir.conjure.parser.ConjureSourceFile;
 import com.palantir.conjure.parser.NormalizeDefinition;
 import com.palantir.conjure.spec.ConjureDefinition;
 import java.io.File;
@@ -34,7 +34,8 @@ public final class Conjure {
      * Deserializes {@link ConjureDefinition} from their YAML representations in the given files.
      */
     public static ConjureDefinition parse(Collection<File> files) {
-        List<ConjureSourceFile> sourceFiles = files.stream().map(ConjureParser::parse).collect(Collectors.toList());
+        List<AnnotatedConjureSourceFile> sourceFiles =
+                files.stream().map(ConjureParser::parseAnnotated).collect(Collectors.toList());
         ConjureDefinition ir = ConjureParserUtils.parseConjureDef(sourceFiles);
         return NormalizeDefinition.normalize(ir);
     }

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureParserUtils.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureParserUtils.java
@@ -291,7 +291,6 @@ public final class ConjureParserUtils {
                         .map(entry -> entry.getValue().visit(
                                 new TypeDefinitionParserVisitor(entry.getKey().name(), defaultPackage, typeResolver)))
                         .collect(Collectors.toMap(td -> td.accept(TypeDefinitionVisitor.TYPE_NAME), td -> td));
-                .map(entry -> entry.getValue().visit(
     }
 
     static List<ErrorDefinition> parseErrors(

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/AnnotatedConjureSourceFile.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/AnnotatedConjureSourceFile.java
@@ -1,0 +1,35 @@
+/*
+ * (c) Copyright 2020 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.parser;
+
+import com.palantir.conjure.defs.ConjureImmutablesStyle;
+import java.io.File;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ConjureImmutablesStyle
+public interface AnnotatedConjureSourceFile {
+    ConjureSourceFile conjureSourceFile();
+
+    File sourceFile();
+
+    class Builder extends ImmutableAnnotatedConjureSourceFile.Builder {}
+
+    static Builder builder() {
+        return new Builder();
+    }
+}

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/ConjureParser.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/ConjureParser.java
@@ -60,6 +60,13 @@ public final class ConjureParser {
         return parser.parse(file);
     }
 
+    public static AnnotatedConjureSourceFile parseAnnotated(File file) {
+        return AnnotatedConjureSourceFile.builder()
+                .conjureSourceFile(ConjureParser.parse(file))
+                .sourceFile(file)
+                .build();
+    }
+
     private static final class RecursiveParser {
         private final Map<String, ConjureSourceFile> cache;
         private final Set<String> currentDepthFirstPath;

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/ConjureDefTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/ConjureDefTest.java
@@ -29,8 +29,8 @@ public class ConjureDefTest {
 
     @Test
     public void resolvesImportedAliases() {
-        ConjureDefinition conjureDefinition = ConjureParserUtils.parseConjureDef(
-                ImmutableList.of(ConjureParser.parse(new File("src/test/resources/example-conjure-imports.yml"))));
+        ConjureDefinition conjureDefinition = ConjureParserUtils.parseConjureDef(ImmutableList.of(
+                ConjureParser.parseAnnotated(new File("src/test/resources/example-conjure-imports.yml"))));
         assertThat(conjureDefinition.getTypes()).hasSize(1);
     }
 
@@ -38,7 +38,7 @@ public class ConjureDefTest {
     @Test
     @Ignore
     public void handlesNonJavaExternalType() {
-        ConjureParserUtils.parseConjureDef(
-                ImmutableList.of(ConjureParser.parse(new File("src/test/resources/example-external-types.yml"))));
+        ConjureParserUtils.parseConjureDef(ImmutableList.of(
+                ConjureParser.parseAnnotated(new File("src/test/resources/example-external-types.yml"))));
     }
 }

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/ConjureSpecTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/ConjureSpecTest.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.parser.AnnotatedConjureSourceFile;
 import com.palantir.conjure.parser.ConjureSourceFile;
@@ -88,7 +89,7 @@ public final class ConjureSpecTest {
                 ConjureParserUtils.parseConjureDef(annotatedConjureDefFrom(yml));
                 Assertions.fail("Conjure for case should be invalid according to the spec: " + testName);
             } catch (Exception e) {
-                Assertions.assertThat(e.getCause())
+                Assertions.assertThat(Throwables.getRootCause(e))
                         .withFailMessage("Failure message for case did not match expectation: "
                                 + testName
                                 + "\nMessage:\n"


### PR DESCRIPTION
## Before this PR
If your conjure definition file failed validation, the old error message would not tell you what file the error was in:

```
java.lang.IllegalStateException: Endpoint 'testEndpoint{http: GET /path}' cannot have multiple body parameters: [arg, arg2]
```

## After this PR
==COMMIT_MSG==
Errors encountered when parsing or validating conjure definition files will now tell you which file the error was found in.
==COMMIT_MSG==

The error now looks like:

```
java.lang.RuntimeException: Encountered error trying to parse file 'test'
// stacktrace
Caused by: java.lang.IllegalStateException: Endpoint 'testEndpoint{http: GET /path}' cannot have multiple body parameters: [arg, arg2]
```

## Possible downsides?
More complicated code.

