### PR TITLE
External import supports binary base type

### DIFF
--- a/conjure-core/src/main/java/com/palantir/conjure/parser/types/names/TypeName.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/types/names/TypeName.java
@@ -22,6 +22,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.palantir.conjure.defs.ConjureImmutablesStyle;
 import com.palantir.conjure.parser.types.NamedTypesDefinition;
+import com.palantir.conjure.spec.PrimitiveType;
+import java.util.Arrays;
 import java.util.regex.Pattern;
 import org.immutables.value.Value;
 
@@ -34,9 +36,9 @@ import org.immutables.value.Value;
 public abstract class TypeName {
 
     private static final Pattern CUSTOM_TYPE_PATTERN = Pattern.compile("^[A-Z][a-z0-9]+([A-Z][a-z0-9]+)*$");
-    static final ImmutableSet<String> PRIMITIVE_TYPES =
-            ImmutableSet.of(
-                    "any", "string", "integer", "double", "boolean", "safelong", "rid", "bearertoken", "uuid");
+    private static final ImmutableSet<String> PRIMITIVE_TYPES = Arrays.stream(PrimitiveType.Value.values())
+            .map(value -> value.name().toLowerCase())
+            .collect(ImmutableSet.toImmutableSet());
 
     @JsonValue
     public abstract String name();

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/types/primitive/PrimitiveType.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/types/primitive/PrimitiveType.java
@@ -33,6 +33,7 @@ public enum PrimitiveType implements LocalReferenceType {
     STRING(TypeName.of("string")),
     INTEGER(TypeName.of("integer")),
     DOUBLE(TypeName.of("double")),
+    BINARY(TypeName.of("binary")),
     BOOLEAN(TypeName.of("boolean")),
     SAFELONG(TypeName.of("safelong")),
     RID(TypeName.of("rid")),

--- a/conjure-core/src/test/java/com/palantir/conjure/parser/ConjureParserTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/parser/ConjureParserTest.java
@@ -68,6 +68,8 @@ public class ConjureParserTest {
         ConjureSourceFile conjure = ConjureParser.parse(new File("src/test/resources/example-external-types.yml"));
         assertThat(conjure.types().imports().get(TypeName.of("ExampleAnyImport")).baseType())
                 .isEqualTo(PrimitiveType.fromString("any"));
+        assertThat(conjure.types().imports().get(TypeName.of("ExampleBinaryImport")).baseType())
+                .isEqualTo(PrimitiveType.fromString("binary"));
     }
 
     @Test

--- a/conjure-core/src/test/resources/example-external-types.yml
+++ b/conjure-core/src/test/resources/example-external-types.yml
@@ -8,6 +8,9 @@ types:
       base-type: string
       external:
         java: com.palantir.example.ExternalIntegerImport
+    ExampleBinaryImport:
+      base-type: binary
+      external: com.palantir.example.ExampleBinaryImport
 
   # Required otherwise imports are ignored by the compiler
   definitions:


### PR DESCRIPTION
Closes #579 

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
==COMMIT_MSG==
External imports can have binary as their base type
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

