### PR TITLE
cache parsed results across multiple runs

### DIFF
--- a/changelog/@unreleased/pr-667.v2.yml
+++ b/changelog/@unreleased/pr-667.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Each conjure file will only be parsed once
+  urls:
+    - https://github.com/palantir/conjure/pull/667

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/Conjure.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/Conjure.java
@@ -23,7 +23,6 @@ import com.palantir.conjure.spec.ConjureDefinition;
 import java.io.File;
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public final class Conjure {
     public static final Integer SUPPORTED_IR_VERSION = 1;
@@ -34,8 +33,7 @@ public final class Conjure {
      * Deserializes {@link ConjureDefinition} from their YAML representations in the given files.
      */
     public static ConjureDefinition parse(Collection<File> files) {
-        List<AnnotatedConjureSourceFile> sourceFiles =
-                files.stream().map(ConjureParser::parseAnnotated).collect(Collectors.toList());
+        List<AnnotatedConjureSourceFile> sourceFiles = ConjureParser.parseAnnotated(files);
         ConjureDefinition ir = ConjureParserUtils.parseConjureDef(sourceFiles);
         return NormalizeDefinition.normalize(ir);
     }

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/ConjureParser.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/ConjureParser.java
@@ -30,8 +30,10 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -61,8 +63,18 @@ public final class ConjureParser {
     }
 
     public static AnnotatedConjureSourceFile parseAnnotated(File file) {
+        RecursiveParser parser = new RecursiveParser();
+        return parseAnnotated(parser, file);
+    }
+
+    public static List<AnnotatedConjureSourceFile> parseAnnotated(Collection<File> files) {
+        RecursiveParser parser = new RecursiveParser();
+        return files.stream().map(file -> parseAnnotated(parser, file)).collect(Collectors.toList());
+    }
+
+    private static AnnotatedConjureSourceFile parseAnnotated(RecursiveParser parser, File file) {
         return AnnotatedConjureSourceFile.builder()
-                .conjureSourceFile(ConjureParser.parse(file))
+                .conjureSourceFile(parser.parse(file))
                 .sourceFile(file)
                 .build();
     }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Parsed results were not cached between runs, so certain common files could be parsed many times in a single run.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Each conjure file will only be parsed once
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
The code is no longer thread safe due to sharing of a static HashMap across threads, but the cli is single-threaded.

