### PR TITLE
Revert "cache parsed results across multiple runs (#667)"

### DIFF
--- a/changelog/@unreleased/pr-674.v2.yml
+++ b/changelog/@unreleased/pr-674.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Reverts change to add parsing caching for conjure files, which broke
+    conjure IR outputting.
+  links:
+  - https://github.com/palantir/conjure/pull/674

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/Conjure.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/Conjure.java
@@ -23,6 +23,7 @@ import com.palantir.conjure.spec.ConjureDefinition;
 import java.io.File;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public final class Conjure {
     public static final Integer SUPPORTED_IR_VERSION = 1;
@@ -33,7 +34,8 @@ public final class Conjure {
      * Deserializes {@link ConjureDefinition} from their YAML representations in the given files.
      */
     public static ConjureDefinition parse(Collection<File> files) {
-        List<AnnotatedConjureSourceFile> sourceFiles = ConjureParser.parseAnnotated(files);
+        List<AnnotatedConjureSourceFile> sourceFiles =
+                files.stream().map(ConjureParser::parseAnnotated).collect(Collectors.toList());
         ConjureDefinition ir = ConjureParserUtils.parseConjureDef(sourceFiles);
         return NormalizeDefinition.normalize(ir);
     }

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/ConjureParser.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/ConjureParser.java
@@ -30,10 +30,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -63,18 +61,8 @@ public final class ConjureParser {
     }
 
     public static AnnotatedConjureSourceFile parseAnnotated(File file) {
-        RecursiveParser parser = new RecursiveParser();
-        return parseAnnotated(parser, file);
-    }
-
-    public static List<AnnotatedConjureSourceFile> parseAnnotated(Collection<File> files) {
-        RecursiveParser parser = new RecursiveParser();
-        return files.stream().map(file -> parseAnnotated(parser, file)).collect(Collectors.toList());
-    }
-
-    private static AnnotatedConjureSourceFile parseAnnotated(RecursiveParser parser, File file) {
         return AnnotatedConjureSourceFile.builder()
-                .conjureSourceFile(parser.parse(file))
+                .conjureSourceFile(ConjureParser.parse(file))
                 .sourceFile(file)
                 .build();
     }


### PR DESCRIPTION
This reverts commit 5715c5ce4cf0dc7dc5c51de8709c57666f4943ec / #667.

## Before this PR
After 4.11.0, conjure seemingly does nothing at all. If you delete a chunk of your conjure yml file, such that it isn't even valid yaml, then rerun `./gradlew compileConjure`, it does produce an error. If you make a valid change, it does not produce updated conjure IR.

## After this PR
==COMMIT_MSG==
Reverts change to add parsing caching for conjure files, which broke conjure IR outputting.
==COMMIT_MSG==

## Possible downsides?
None, I think, as it does not seem to work. It's kind of worrying we have no test failures (going to check they are actually running!). The caching feature sounds useful if it speeds up the build, so it may be worth giving it another go with tests to ensure it still works.

cc @rzpt.
