### PR TITLE
fix: correctly set exit code on failure

### DIFF
--- a/changelog/@unreleased/pr-675.v2.yml
+++ b/changelog/@unreleased/pr-675.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: correctly set exit code on failure.
+  links:
+  - https://github.com/palantir/conjure/pull/675

--- a/conjure/src/main/java/com/palantir/conjure/cli/ConjureCli.java
+++ b/conjure/src/main/java/com/palantir/conjure/cli/ConjureCli.java
@@ -43,7 +43,7 @@ public final class ConjureCli implements Runnable {
             .setSerializationInclusion(JsonInclude.Include.NON_ABSENT);
 
     public static void main(String[] args) {
-        new CommandLine(new ConjureCli()).execute(args);
+        System.exit(new CommandLine(new ConjureCli()).execute(args));
     }
 
     @Override


### PR DESCRIPTION
## Before this PR
Due to an upgrade of picocli we would swallow errors and always exit 0

## After this PR
==COMMIT_MSG==
correctly set exit code on failure.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

