### PR TITLE
feature: add per endpoint tags

### DIFF
--- a/changelog/@unreleased/pr-702.v2.yml
+++ b/changelog/@unreleased/pr-702.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Add `tags` field to `EndpointDefinition` in the IR
+  links:
+  - https://github.com/palantir/conjure/pull/702

--- a/conjure-api/src/main/conjure/conjure-api.yml
+++ b/conjure-api/src/main/conjure/conjure-api.yml
@@ -186,6 +186,7 @@ types:
           paramType: ParameterType
           docs: optional<Documentation>
           markers: list<Type>
+          tags: list<string>
       ArgumentName:
         alias: string
         docs: >

--- a/conjure-api/src/main/conjure/conjure-api.yml
+++ b/conjure-api/src/main/conjure/conjure-api.yml
@@ -158,6 +158,7 @@ types:
           docs: optional<Documentation>
           deprecated: optional<Documentation>
           markers: list<Type>
+          tags: set<string>
       EndpointName:
         alias: string
         docs: Should be in lowerCamelCase.

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureParserUtils.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureParserUtils.java
@@ -72,6 +72,7 @@ import com.palantir.conjure.spec.TypeName;
 import com.palantir.conjure.spec.UnionDefinition;
 import com.palantir.conjure.visitor.DealiasingTypeVisitor;
 import com.palantir.conjure.visitor.TypeDefinitionVisitor;
+import com.palantir.logsafe.Preconditions;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -363,7 +364,9 @@ public final class ConjureParserUtils {
                 .httpPath(httpPath)
                 .auth(def.auth().map(ConjureParserUtils::parseAuthType).orElse(defaultAuth))
                 .args(parseArgs(def.args(), httpPath, typeResolver))
-                .tags(def.tags())
+                .tags(def.tags().stream()
+                        .peek(tag -> Preconditions.checkArgument(!tag.isEmpty(), "tag must not be empty"))
+                        .collect(Collectors.toSet()))
                 .markers(parseMarkers(def.markers(), typeResolver))
                 .returns(def.returns().map(t -> t.visit(new ConjureTypeParserVisitor(typeResolver))))
                 .docs(def.docs().map(Documentation::of))
@@ -414,7 +417,9 @@ public final class ConjureParserUtils {
                     .paramType(paramType)
                     .docs(original.docs().map(Documentation::of))
                     .markers(parseMarkers(original.markers(), typeResolver))
-                    .tags(original.tags());
+                    .tags(original.tags().stream()
+                            .peek(tag -> Preconditions.checkArgument(!tag.isEmpty(), "tag must not be empty"))
+                            .collect(Collectors.toSet()));
             resultBuilder.add(builder.build());
         }
         return resultBuilder.build();

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureParserUtils.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureParserUtils.java
@@ -413,7 +413,8 @@ public final class ConjureParserUtils {
                     .type(original.type().visit(new ConjureTypeParserVisitor(typeResolver)))
                     .paramType(paramType)
                     .docs(original.docs().map(Documentation::of))
-                    .markers(parseMarkers(original.markers(), typeResolver));
+                    .markers(parseMarkers(original.markers(), typeResolver))
+                    .tags(original.tags());
             resultBuilder.add(builder.build());
         }
         return resultBuilder.build();

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureParserUtils.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureParserUtils.java
@@ -363,6 +363,7 @@ public final class ConjureParserUtils {
                 .httpPath(httpPath)
                 .auth(def.auth().map(ConjureParserUtils::parseAuthType).orElse(defaultAuth))
                 .args(parseArgs(def.args(), httpPath, typeResolver))
+                .tags(def.tags())
                 .markers(parseMarkers(def.markers(), typeResolver))
                 .returns(def.returns().map(t -> t.visit(new ConjureTypeParserVisitor(typeResolver))))
                 .docs(def.docs().map(Documentation::of))

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/services/ArgumentDefinition.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/services/ArgumentDefinition.java
@@ -53,6 +53,8 @@ public interface ArgumentDefinition {
 
     Set<ConjureType> markers();
 
+    Set<String> tags();
+
     enum ParamType {
         /**
          * Choose PathParam when this argument appears in the http line, treat as body otherwise.

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/services/EndpointDefinition.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/services/EndpointDefinition.java
@@ -35,6 +35,8 @@ public interface EndpointDefinition {
 
     Map<ParameterName, ArgumentDefinition> args();
 
+    Set<String> tags();
+
     Set<ConjureType> markers();
 
     Optional<ConjureType> returns();

--- a/conjure-core/src/test/java/com/palantir/conjure/parser/services/ServiceDefinitionTests.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/parser/services/ServiceDefinitionTests.java
@@ -282,6 +282,7 @@ public final class ServiceDefinitionTests {
                                                 "post",
                                                 EndpointDefinition.builder()
                                                         .http(RequestLineDefinition.of("POST", PathString.of("/post")))
+                                                        .addTags("test-tag")
                                                         .args(ImmutableMap.of(
                                                                 ParameterName.of("foo"),
                                                                 ArgumentDefinition.builder()

--- a/conjure-core/src/test/java/com/palantir/conjure/parser/services/ServiceDefinitionTests.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/parser/services/ServiceDefinitionTests.java
@@ -289,6 +289,7 @@ public final class ServiceDefinitionTests {
                                                                         .paramType(ArgumentDefinition.ParamType.HEADER)
                                                                         .type(LocalReferenceType.of(
                                                                                 TypeName.of("StringAlias")))
+                                                                        .addTags("safe")
                                                                         .build()))
                                                         .build())
                                         .build())

--- a/conjure-core/src/test/resources/normalized.conjure.json
+++ b/conjure-core/src/test/resources/normalized.conjure.json
@@ -96,7 +96,8 @@
       "returns" : null,
       "docs" : null,
       "deprecated" : null,
-      "markers" : [ ]
+      "markers" : [ ],
+      "tags" : [ ]
     } ],
     "docs" : null
   }, {
@@ -113,7 +114,8 @@
       "returns" : null,
       "docs" : null,
       "deprecated" : null,
-      "markers" : [ ]
+      "markers" : [ ],
+      "tags" : [ ]
     } ],
     "docs" : null
   } ],

--- a/conjure-core/src/test/resources/test-service.yml
+++ b/conjure-core/src/test/resources/test-service.yml
@@ -31,3 +31,4 @@ services:
           foo:
             type: StringAlias
             param-type: header
+            tags: ['safe']

--- a/conjure-core/src/test/resources/test-service.yml
+++ b/conjure-core/src/test/resources/test-service.yml
@@ -25,6 +25,7 @@ services:
         http: GET /get
 
       post:
+        tags: ['test-tag']
         http: POST /post
         args:
           foo:

--- a/docs/spec/conjure_definitions.md
+++ b/docs/spec/conjure_definitions.md
@@ -348,6 +348,7 @@ returns | [ConjureType][] | The name of the return type of the endpoint. The val
 args | Map[`string` &rarr; [ArgumentDefinition][]&nbsp;or&nbsp;[ConjureType][]] | A map between argument names and argument definitions. If the value of the field is a `string` it MUST be a type name that exists within the Conjure definition. Furthermore, if a `string` the argument will default to `auto` [ArgumentDefinition.ParamType][].
 docs | [DocString][] | Documentation for the endpoint. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 deprecated | [DocString][] | Documentation for the deprecation of the endpoint. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
+tags | Set[`string`] | Set of tags that serves as additional metadata for the endpoint.
 
 
 ## ArgumentDefinition

--- a/docs/spec/conjure_definitions.md
+++ b/docs/spec/conjure_definitions.md
@@ -361,7 +361,8 @@ type | [ConjureType][] | **REQUIRED**. The type of the value of the argument. Th
 If the param-type is `path` then the de-aliased type MUST be an enum or a primitive (except `binary`, and `bearertoken`).
 If the param-type is `query` then the de-aliased type MUST be an enum or a primitive (except `binary` and `bearertoken`), or a container (list, set, optional) of one of these.
 If the param-type is `header` then the de-aliased type MUST be an enum or a primitive (except binary), or an optional of one of these.
-markers | List[`string`] | List of types that serve as additional metadata for the argument. If the value of the field is a `string` it MUST be a type name that exists within the Conjure definition.
+markers | List[`string`] | List of types that serve as additional metadata for the argument. If the value of the field is a `string` it MUST be a type name that exists within the Conjure definition. Prefer to use tags instead of markers.
+tags | Set[`string`] | Set of tags that serves as additional metadata for the argument.
 param&#8209;id | `string` | An identifier to use as a parameter value. If the param type is `header` or `query`, this field may be populated to define the identifier that is used over the wire. If this field is undefined for the `header` or `query` param types, the argument name is used as the wire identifier. Population of this field is invalid if the param type is not `header` or `query`.
 param&#8209;type | [ArgumentDefinition.ParamType][] | The type of the endpoint parameter. If omitted the default type is `auto`.
 


### PR DESCRIPTION
Closes #612
## Before this PR
users were able to annotate endpoints with type `markers` which was used by Java generator to apply annotations to endpoints or to indicate to the generator to different endpoint signatures (ex. Java-undertow and `Async` type). This was problematic since the type based approach limited the usefulness of markers to Java projects as well as prevented users from adding metadata to their definitions that could be used non-generator consumers of the IR (i.e. Documentation services)

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add `tags` field to `EndpointDefinition` in the IR
==COMMIT_MSG==

Any values provided in this field must not impact the wire structure of the endpoint and should not be considered when evaluating backwards compatability.

## Possible downsides?
Duplicated functionality with `markers` could be confusing and the untyped set of tags leaves a lot of room for potential misuse 

