### PR TITLE
publish jar for use in gradle

### DIFF
--- a/conjure/build.gradle
+++ b/conjure/build.gradle
@@ -15,6 +15,7 @@
  */
 
 apply from: "$rootDir/gradle/publish-dist.gradle"
+apply from: "$rootDir/gradle/publish-jar.gradle"
 
 mainClassName = 'com.palantir.conjure.cli.ConjureCli'
 

--- a/conjure/src/main/java/com/palantir/conjure/cli/ConjureCli.java
+++ b/conjure/src/main/java/com/palantir/conjure/cli/ConjureCli.java
@@ -43,7 +43,7 @@ public final class ConjureCli implements Runnable {
             .setSerializationInclusion(JsonInclude.Include.NON_ABSENT);
 
     public static void main(String[] args) {
-        System.exit(new CommandLine(new ConjureCli()).execute(args));
+        new CommandLine(new ConjureCli()).execute(args);
     }
 
     @Override


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
conjure was only published as a dist so it could be used as a cli.



## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Publish conjure as a jar so that it can be invoked in process in gradle so it does not unnecessarily consume extra resources.

==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
No downsides. Maybe someone was relying on the exit code, but conjure-java does not exit in this way.


