### PR TITLE
fix: tags are consistently sets

### DIFF
--- a/changelog/@unreleased/pr-736.v2.yml
+++ b/changelog/@unreleased/pr-736.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: tags are consistently sets
+  links:
+  - https://github.com/palantir/conjure/pull/736

--- a/conjure-api/src/main/conjure/conjure-api.yml
+++ b/conjure-api/src/main/conjure/conjure-api.yml
@@ -186,7 +186,7 @@ types:
           paramType: ParameterType
           docs: optional<Documentation>
           markers: list<Type>
-          tags: list<string>
+          tags: set<string>
       ArgumentName:
         alias: string
         docs: >


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
tags are consistently sets
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

