### PR TITLE
Fix conjure-imports example in conjure_definitions.md 

### DIFF
--- a/docs/spec/conjure_definitions.md
+++ b/docs/spec/conjure_definitions.md
@@ -79,7 +79,7 @@ types:
     default-package: com.palantir.product
     objects:
       SomeRequest:
-        id: common.ProductId
+        alias: common.ProductId
 ```
 
 ## ExternalTypeDefinition


### PR DESCRIPTION
## Before this PR
The following exception would occur whilst compiling the example.
```
com.palantir.logsafe.exceptions.SafeIllegalArgumentException: Unrecognized definition, types must have either fields, values or an alias defined.
```

## After this PR
When compiling just the example.yml and common.yml there is a NullPointerException, but at least the definition can be parsed properly.
