### PR TITLE
Update error message of invalid type

### DIFF
--- a/changelog/@unreleased/pr-804.v2.yml
+++ b/changelog/@unreleased/pr-804.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Includes binary and datetime in suggested built-in types in the error message of invalid type.
+  links:
+  - https://github.com/palantir/conjure/pull/804

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/types/names/TypeName.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/types/names/TypeName.java
@@ -19,10 +19,13 @@ package com.palantir.conjure.parser.types.names;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableSet;
 import com.palantir.conjure.defs.ConjureImmutablesStyle;
 import com.palantir.conjure.parser.types.NamedTypesDefinition;
+import com.palantir.conjure.spec.PrimitiveType;
+import java.util.Arrays;
+import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.immutables.value.Value;
 
 /**
@@ -34,8 +37,11 @@ import org.immutables.value.Value;
 public abstract class TypeName {
 
     private static final Pattern CUSTOM_TYPE_PATTERN = Pattern.compile("^[A-Z][a-z0-9]+([A-Z][a-z0-9]+)*$");
-    static final ImmutableSet<String> PRIMITIVE_TYPES =
-            ImmutableSet.of("any", "string", "integer", "double", "boolean", "safelong", "rid", "bearertoken", "uuid");
+    static final Set<String> PRIMITIVE_TYPES = Arrays.stream(PrimitiveType.Value.values())
+            .filter(type -> type != PrimitiveType.Value.UNKNOWN)
+            .map(PrimitiveType.Value::name)
+            .map(String::toLowerCase)
+            .collect(Collectors.toSet());
 
     @JsonValue
     public abstract String name();

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/types/names/TypeName.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/types/names/TypeName.java
@@ -22,7 +22,6 @@ import com.google.common.base.Preconditions;
 import com.palantir.conjure.defs.ConjureImmutablesStyle;
 import com.palantir.conjure.parser.types.NamedTypesDefinition;
 import com.palantir.conjure.spec.PrimitiveType;
-import java.util.Arrays;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -37,9 +36,8 @@ import org.immutables.value.Value;
 public abstract class TypeName {
 
     private static final Pattern CUSTOM_TYPE_PATTERN = Pattern.compile("^[A-Z][a-z0-9]+([A-Z][a-z0-9]+)*$");
-    static final Set<String> PRIMITIVE_TYPES = Arrays.stream(PrimitiveType.Value.values())
-            .filter(type -> type != PrimitiveType.Value.UNKNOWN)
-            .map(PrimitiveType.Value::name)
+    static final Set<String> PRIMITIVE_TYPES = PrimitiveType.values().stream()
+            .map(PrimitiveType::toString)
             .map(String::toLowerCase)
             .collect(Collectors.toSet());
 

--- a/conjure-core/src/test/java/com/palantir/conjure/parser/types/TypeParserTests.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/parser/types/TypeParserTests.java
@@ -17,6 +17,7 @@
 package com.palantir.conjure.parser.types;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.palantir.conjure.parser.types.builtin.AnyType;
@@ -163,5 +164,17 @@ public final class TypeParserTests {
     public void testDeserializer_listType() throws IOException {
         assertThat(new ObjectMapper().readValue("\"list<string>\"", ConjureType.class))
                 .isEqualTo(ListType.of(PrimitiveType.STRING));
+    }
+
+    @Test
+    public void testInvalidNames() {
+        String invalid = "bytes";
+        assertThatThrownBy(() -> TypeParser.INSTANCE.parse(invalid))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "TypeNames must be a primitive type [datetime, boolean, string, double, bearertoken, binary,"
+                            + " safelong, integer, rid, any, uuid] or match pattern ^[A-Z][a-z0-9]+([A-Z][a-z0-9]+)*$:"
+                            + " %s",
+                        invalid);
     }
 }


### PR DESCRIPTION
## Before this PR
```
Caused by: java.lang.IllegalArgumentException: TypeNames must be a primitive type [any, string, integer, double, boolean, safelong, rid, bearertoken, uuid] or match pattern ^[A-Z][a-z0-9]+([A-Z][a-z0-9]+)*$: bytes
``` 
when use invalid type `bytes`, i got that error message on `classpath 'com.palantir.gradle.conjure:gradle-conjure:5.1.1'`. It's missing `binary` and `datetime` 
## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Includes binary and datetime in suggested built-in types in the error message of invalid type. 
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

