### PR TITLE
Fix TypeParserTests

### DIFF
--- a/changelog/@unreleased/pr-811.v2.yml
+++ b/changelog/@unreleased/pr-811.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: >
+    An incorrect Type parsing now throws IllegalArgumentException with an informative error message rather than simply
+    ParseException.
+  link: https://github.com/palantir/conjure/issues/812

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/types/TypeParser.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/types/TypeParser.java
@@ -90,13 +90,7 @@ public enum TypeParser implements Parser<ConjureType> {
                 input.rewind();
                 return null;
             }
-            TypeName typeName;
-            try {
-                typeName = TypeName.of(typeReference);
-            } catch (IllegalArgumentException _e) {
-                input.rewind();
-                return null;
-            }
+            TypeName typeName = TypeName.of(typeReference);
             input.release();
             return LocalReferenceType.of(typeName);
         }

--- a/conjure-core/src/test/java/com/palantir/conjure/parser/types/TypeParserTests.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/parser/types/TypeParserTests.java
@@ -90,7 +90,7 @@ public final class TypeParserTests {
         assertThat(TypeParser.INSTANCE.parse("bar_1.Foo"))
                 .isEqualTo(ForeignReferenceType.of(Namespace.of("bar_1"), TypeName.of("Foo")));
 
-        assertThatThrownBy(() -> TypeParser.INSTANCE.parse("1_bar.Foo")).isInstanceOf(ParseException.class);
+        assertThatThrownBy(() -> TypeParser.INSTANCE.parse("1_bar.Foo")).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
@@ -178,8 +178,8 @@ public final class TypeParserTests {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage(
                         "TypeNames must be a primitive type [datetime, boolean, string, double, bearertoken, binary,"
-                            + " safelong, integer, rid, any, uuid] or match pattern ^[A-Z][a-z0-9]+([A-Z][a-z0-9]+)*$:"
-                            + " %s",
+                                + " safelong, integer, rid, any, uuid] or match pattern"
+                                + " ^[A-Z][a-z0-9]+([A-Z][a-z0-9]+)*$: %s",
                         invalid);
     }
 }


### PR DESCRIPTION
## Before this PR
Based on my understanding, the test `testParser_foreignRefType` should be throwing an `IllegalArgumentException` rather than a `ParseException` on `1_bar.Foo`, as it doesn't match the required type pattern.

Not sure why this is valid in `master` - the `TypeParser` currently eats `IllegalArgumentException`s, which means that `testInvalidNames` does not pass. If I run this `TypeParserTests` locally on `master` it always fails for me.
## After this PR
==COMMIT_MSG==
Fix type parser to throw informative `IllegalArgumentException` instead of `ParseException`.
==COMMIT_MSG==
