### PR TITLE
Add behaviour to the 'or' parser to pass through errors

### DIFF
--- a/changelog/@unreleased/pr-814.v2.yml
+++ b/changelog/@unreleased/pr-814.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: >
+    When an exception is hit while performing Parser.or, the exception is immediately thrown. Additionally, this
+    current behaviour is causing tests to fail on master. Instead, store and re-throw any exceptions if no other
+    parsers match.
+  link: https://github.com/palantir/conjure/issues/812

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/types/TypeParser.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/types/TypeParser.java
@@ -90,13 +90,7 @@ public enum TypeParser implements Parser<ConjureType> {
                 input.rewind();
                 return null;
             }
-            TypeName typeName;
-            try {
-                typeName = TypeName.of(typeReference);
-            } catch (IllegalArgumentException _e) {
-                input.rewind();
-                return null;
-            }
+            TypeName typeName = TypeName.of(typeReference);
             input.release();
             return LocalReferenceType.of(typeName);
         }

--- a/conjure-core/src/main/java/com/palantir/parsec/ParseException.java
+++ b/conjure-core/src/main/java/com/palantir/parsec/ParseException.java
@@ -27,6 +27,12 @@ public final class ParseException extends Exception {
         this.state = state;
     }
 
+    public ParseException(String message, ParserState state, Exception cause) {
+        super(cause);
+        this.message = message;
+        this.state = state;
+    }
+
     @Override
     public String getMessage() {
 

--- a/conjure-core/src/main/java/com/palantir/parsec/Parsers.java
+++ b/conjure-core/src/main/java/com/palantir/parsec/Parsers.java
@@ -153,11 +153,7 @@ public final class Parsers {
             }
 
             if (exception != null) {
-                ParseException toThrow = new ParseException(exception.getMessage(), input);
-                for (Throwable suppressed : exception.getSuppressed()) {
-                    toThrow.addSuppressed(suppressed);
-                }
-                throw toThrow;
+                throw new ParseException(exception.getMessage(), input, exception);
             }
 
             return null;

--- a/conjure-core/src/main/java/com/palantir/parsec/Parsers.java
+++ b/conjure-core/src/main/java/com/palantir/parsec/Parsers.java
@@ -136,7 +136,11 @@ public final class Parsers {
                 try {
                     result = gingerly(nextOption).parse(input);
                 } catch (RuntimeException e) {
-                    exception = e;
+                    if (exception == null) {
+                        exception = e;
+                    } else {
+                        exception.addSuppressed(e);
+                    }
                 }
 
                 if (result != null) {

--- a/conjure-core/src/test/java/com/palantir/conjure/parser/types/TypeParserTests.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/parser/types/TypeParserTests.java
@@ -179,7 +179,7 @@ public final class TypeParserTests {
                 .hasMessage(
                         "TypeNames must be a primitive type [datetime, boolean, string, double, bearertoken, binary,"
                                 + " safelong, integer, rid, any, uuid] or match pattern ^[A-Z][a-z0-9]+([A-Z][a-z0-9]+)*$:"
-                                + " %s\nat or before character 5\non or before line 0\n",
+                                + " %s\nat or before character 5\non or before line 0\nbytes",
                         invalid);
     }
 }

--- a/conjure-core/src/test/java/com/palantir/conjure/parser/types/TypeParserTests.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/parser/types/TypeParserTests.java
@@ -175,11 +175,11 @@ public final class TypeParserTests {
     public void testInvalidNames() {
         String invalid = "bytes";
         assertThatThrownBy(() -> TypeParser.INSTANCE.parse(invalid))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(ParseException.class)
                 .hasMessage(
                         "TypeNames must be a primitive type [datetime, boolean, string, double, bearertoken, binary,"
-                            + " safelong, integer, rid, any, uuid] or match pattern ^[A-Z][a-z0-9]+([A-Z][a-z0-9]+)*$:"
-                            + " %s",
+                                + " safelong, integer, rid, any, uuid] or match pattern ^[A-Z][a-z0-9]+([A-Z][a-z0-9]+)*$:"
+                                + " %s\nat or before character 5\non or before line 0\n",
                         invalid);
     }
 }

--- a/conjure-core/src/test/java/com/palantir/parsec/tests/TestUnitParsers.java
+++ b/conjure-core/src/test/java/com/palantir/parsec/tests/TestUnitParsers.java
@@ -187,6 +187,8 @@ public final class TestUnitParsers {
         assertThatThrownBy(() -> Parsers.or(alwaysThrows, alwaysThrows).parse(new StringParserState("\"abcdef\"")))
                 .isInstanceOf(ParseException.class)
                 .hasMessage("bad thing\nat or before character 8\non or before line 0\n\"abcdef\"")
+                .hasCause(new IllegalStateException("bad thing"))
+                .getCause()
                 .hasSuppressedException(new IllegalStateException("bad thing"));
     }
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
When an exception is hit while performing `Parser.or`, the exception is immediately thrown. Additionally, this current behaviour is causing tests to fail on master.
## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Change behaviour of `or` parser to instead store any exceptions, and re-throw it as a `ParseException` if no parser successfully completes.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

