### PR TITLE
Validate conjure headers do not set protocol headers.

### DIFF
--- a/changelog/@unreleased/pr-835.v2.yml
+++ b/changelog/@unreleased/pr-835.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Users can no longer set protocol headers (Host, Accept, Content-Type).
+  links:
+  - https://github.com/palantir/conjure/pull/835

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/EndpointDefinitionValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/EndpointDefinitionValidator.java
@@ -17,6 +17,7 @@
 package com.palantir.conjure.defs.validator;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.palantir.conjure.CaseConverter;
 import com.palantir.conjure.either.Either;
@@ -74,6 +75,7 @@ public enum EndpointDefinitionValidator implements ConjureContextualValidator<En
     }
 
     public static final Pattern HEADER_PATTERN = Pattern.compile("^[A-Z][a-zA-Z0-9]*(-[A-Z][a-zA-Z0-9]*)*$");
+    public static final ImmutableSet<String> PROTOCOL_HEADERS = ImmutableSet.of("Host", "Accept", "Content-Type");
 
     private final ConjureContextualValidator<EndpointDefinition> validator;
 
@@ -417,6 +419,13 @@ public enum EndpointDefinitionValidator implements ConjureContextualValidator<En
                             paramId.get(),
                             describe(definition),
                             HEADER_PATTERN);
+
+                    Preconditions.checkState(
+                            !PROTOCOL_HEADERS.contains(paramId.get()),
+                            "Header parameter id %s on endpoint %s should not be one of the protocol headers %s",
+                            paramId.get(),
+                            describe(definition),
+                            PROTOCOL_HEADERS);
 
                 } else if (paramType.accept(ParameterTypeVisitor.IS_QUERY)) {
                     ParameterId paramId =


### PR DESCRIPTION
## Before this PR

Conjure users can set headers that we use for the low level protocol.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Users can no longer set protocol headers (Host, Accept, Content-Type).
==COMMIT_MSG==

## Possible downsides?

Someone is relying on this already?

