### PR TITLE
Fix broken liche checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,10 +143,10 @@ jobs:
       - store_artifacts: { path: ~/artifacts }
 
   markdown:
-    docker: [{ image: 'raviqqe/liche:0.1.1' }]
+    docker: [{ image: 'lycheeverse/lychee:0.6.0' }]
     steps:
       - checkout
-      - run: /liche -d . -r . -v
+      - run: lychee **/*.md
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
     docker: [{ image: 'lycheeverse/lychee:0.6.0' }]
     steps:
       - checkout
-      - run: lychee --exclude-loopback **/*.md
+      - run: lychee --exclude-all-private **/*.md
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ jobs:
       - store_artifacts: { path: ~/artifacts }
 
   markdown:
-    docker: [{ image: 'raviqqe/liche:0.1.1' }]
+    docker: [{ image: 'raviqqe/liche:0.2.0' }]
     steps:
       - checkout
       - run: /liche -d . -r . -v

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
     docker: [{ image: 'lycheeverse/lychee:0.6.0' }]
     steps:
       - checkout
-      - run: lychee --exclude-all-private --exclude localhost --verbose **/*.md
+      - run: lychee --exclude-all-private --exclude localhost --no-progress *.md **/*.md
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
     docker: [{ image: 'lycheeverse/lychee:0.6.0' }]
     steps:
       - checkout
-      - run: lychee --exclude-all-private **/*.md
+      - run: lychee --exclude-all-private --exclude localhost --verbose **/*.md
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ jobs:
       - store_artifacts: { path: ~/artifacts }
 
   markdown:
-    docker: [{ image: 'raviqqe/liche:0.2.0' }]
+    docker: [{ image: 'raviqqe/liche:0.1.1' }]
     steps:
       - checkout
       - run: /liche -d . -r . -v

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ jobs:
     docker: [{ image: 'lycheeverse/lychee:0.6.0' }]
     steps:
       - checkout
-      - run: lychee **/*.md
+      - run: lychee --exclude-loopback **/*.md
 
 
 workflows:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,6 @@ If your change affects just one language or client, you'll probably just need to
   - [conjure-java](https://github.com/palantir/conjure-java)
   - [conjure-java-runtime](https://github.com/palantir/conjure-java-runtime)
   - [conjure-typescript](https://github.com/palantir/conjure-typescript)
-  - [conjure-typescript-client](https://github.com/palantir/conjure-typescript-client)
   - [conjure-python](https://github.com/palantir/conjure-python)
   - [conjure-python-client](https://github.com/palantir/conjure-python-client)
 

--- a/changelog/@unreleased/pr-848.v2.yml
+++ b/changelog/@unreleased/pr-848.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Remove docs link to https://www.getpostman.com/ so builds pass again.
+  links:
+  - https://github.com/palantir/conjure/pull/848

--- a/changelog/@unreleased/pr-848.v2.yml
+++ b/changelog/@unreleased/pr-848.v2.yml
@@ -1,5 +1,5 @@
 type: fix
 fix:
-  description: Remove docs link to https://www.getpostman.com/ so builds pass again.
+  description: Replace liche with lychee for markdown link checking
   links:
   - https://github.com/palantir/conjure/pull/848

--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ The [conjure-verification](https://github.com/palantir/conjure-verification) too
 
 The following tools also operate on IR:
 
-- [conjure-postman](https://github.com/palantir/conjure-postman) - generates [Postman](https://learning.postman.com/) [Collections](https://learning.getpostman.com/docs/postman/collections/intro-to-collections/) for interacting with Conjure defined APIs.
+- [conjure-postman](https://github.com/palantir/conjure-postman) - generates [Postman Collections](https://learning.getpostman.com/docs/postman/collections/intro-to-collections/) for interacting with Conjure defined APIs.
 - conjure-backcompat - an experimental type checker that compares two IR definitions to evaluate whether they are wire format compatible (not yet open-sourced).
 
 

--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ The [conjure-verification](https://github.com/palantir/conjure-verification) too
 
 The following tools also operate on IR:
 
-- [conjure-postman](https://github.com/palantir/conjure-postman) - generates [Postman](https://www.learning.postman.com/) [Collections](https://learning.getpostman.com/docs/postman/collections/intro-to-collections/) for interacting with Conjure defined APIs.
+- [conjure-postman](https://github.com/palantir/conjure-postman) - generates [Postman](https://learning.postman.com/) [Collections](https://learning.getpostman.com/docs/postman/collections/intro-to-collections/) for interacting with Conjure defined APIs.
 - conjure-backcompat - an experimental type checker that compares two IR definitions to evaluate whether they are wire format compatible (not yet open-sourced).
 
 

--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ The [conjure-verification](https://github.com/palantir/conjure-verification) too
 
 The following tools also operate on IR:
 
-- [conjure-postman](https://github.com/palantir/conjure-postman) - generates [Postman Collections](https://learning.getpostman.com/docs/postman/collections/intro-to-collections/) for interacting with Conjure defined APIs.
+- [conjure-postman](https://github.com/palantir/conjure-postman) - generates [Postman](https://www.getpostman.com/) [Collections](https://learning.getpostman.com/docs/postman/collections/intro-to-collections/) for interacting with Conjure defined APIs.
 - conjure-backcompat - an experimental type checker that compares two IR definitions to evaluate whether they are wire format compatible (not yet open-sourced).
 
 

--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ The [conjure-verification](https://github.com/palantir/conjure-verification) too
 
 The following tools also operate on IR:
 
-- [conjure-postman](https://github.com/palantir/conjure-postman) - generates [Postman](https://www.getpostman.com/) [Collections](https://learning.getpostman.com/docs/postman/collections/intro-to-collections/) for interacting with Conjure defined APIs.
+- [conjure-postman](https://github.com/palantir/conjure-postman) - generates [Postman](https://www.learning.postman.com/) [Collections](https://learning.getpostman.com/docs/postman/collections/intro-to-collections/) for interacting with Conjure defined APIs.
 - conjure-backcompat - an experimental type checker that compares two IR definitions to evaluate whether they are wire format compatible (not yet open-sourced).
 
 


### PR DESCRIPTION
## Before this PR
https://www.getpostman.com/ has too large of a header for the `liche` checks. It doesn't look like there's a way to easily expand the read headers (that I can see), so I just combined the postman-collections link into one.

Example of failing build caused by this: https://app.circleci.com/pipelines/github/palantir/conjure/1132/workflows/8965f3da-1ad6-42bc-b4d4-1365648a2247/jobs/9751

## After this PR
==COMMIT_MSG==
Remove docs link to https://www.getpostman.com/ so builds pass again.
==COMMIT_MSG==
