### PR TITLE
Clean up error message from CLI

### DIFF
--- a/changelog/@unreleased/pr-873.v2.yml
+++ b/changelog/@unreleased/pr-873.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Clean up error messages generated from the CLI
+  links:
+  - https://github.com/palantir/conjure/pull/873

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureParserUtils.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureParserUtils.java
@@ -31,6 +31,8 @@ import com.palantir.conjure.defs.validator.PackageValidator;
 import com.palantir.conjure.defs.validator.ServiceDefinitionValidator;
 import com.palantir.conjure.defs.validator.TypeNameValidator;
 import com.palantir.conjure.defs.validator.UnionDefinitionValidator;
+import com.palantir.conjure.exceptions.ConjureIllegalArgumentException;
+import com.palantir.conjure.exceptions.ConjureRuntimeException;
 import com.palantir.conjure.parser.AnnotatedConjureSourceFile;
 import com.palantir.conjure.parser.ConjureSourceFile;
 import com.palantir.conjure.parser.services.ParameterName;
@@ -224,7 +226,7 @@ public final class ConjureParserUtils {
                 typesBuilder.addAll(objects.values());
                 errorsBuilder.addAll(parseErrors(parsed.types().definitions(), typeResolver));
             } catch (RuntimeException e) {
-                throw new RuntimeException(
+                throw new ConjureRuntimeException(
                         String.format("Encountered error trying to parse file '%s'", annotatedParsed.sourceFile()), e);
             }
         });
@@ -394,7 +396,7 @@ public final class ConjureParserUtils {
             case NONE:
                 return Optional.empty();
             default:
-                throw new SafeIllegalArgumentException("Unrecognized auth type.");
+                throw new ConjureIllegalArgumentException("Unrecognized auth type.");
         }
     }
 
@@ -451,7 +453,7 @@ public final class ConjureParserUtils {
                         argumentDef.paramId().map(ParameterName::name).orElseGet(argName::get);
                 return ParameterType.query(QueryParameterType.of(ParameterId.of(queryParamId)));
             default:
-                throw new IllegalArgumentException("Unknown parameter type: " + argumentDef.paramType());
+                throw new ConjureIllegalArgumentException("Unknown parameter type: " + argumentDef.paramType());
         }
     }
 

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureTypeParserVisitor.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureTypeParserVisitor.java
@@ -17,6 +17,7 @@
 package com.palantir.conjure.defs;
 
 import com.google.common.base.Preconditions;
+import com.palantir.conjure.exceptions.ConjureIllegalStateException;
 import com.palantir.conjure.parser.types.BaseObjectTypeDefinition;
 import com.palantir.conjure.parser.types.ConjureTypeVisitor;
 import com.palantir.conjure.parser.types.TypesDefinition;
@@ -79,7 +80,7 @@ public final class ConjureTypeParserVisitor implements ConjureTypeVisitor<Type> 
             if (maybeDirectDef == null) {
                 ExternalTypeDefinition maybeExternalDef = types.imports().get(name);
                 if (maybeExternalDef == null) {
-                    throw new IllegalStateException("Unknown LocalReferenceType: " + name);
+                    throw new ConjureIllegalStateException("Unknown LocalReferenceType: " + name);
                 }
 
                 String externalPath = maybeExternalDef.external().java();

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/EndpointDefinitionValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/EndpointDefinitionValidator.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.palantir.conjure.CaseConverter;
 import com.palantir.conjure.either.Either;
+import com.palantir.conjure.exceptions.ConjureRuntimeException;
 import com.palantir.conjure.spec.ArgumentDefinition;
 import com.palantir.conjure.spec.ArgumentName;
 import com.palantir.conjure.spec.EndpointDefinition;
@@ -40,7 +41,6 @@ import com.palantir.conjure.visitor.DealiasingTypeVisitor;
 import com.palantir.conjure.visitor.ParameterTypeVisitor;
 import com.palantir.conjure.visitor.TypeDefinitionVisitor;
 import com.palantir.conjure.visitor.TypeVisitor;
-import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -329,17 +329,20 @@ public enum EndpointDefinitionValidator implements ConjureContextualValidator<En
                                 // DealiasingTypeVisitor above
                                 @Override
                                 public Boolean visitReference(TypeName _value) {
-                                    throw new SafeRuntimeException("Unexpected type when validating query parameters");
+                                    throw new ConjureRuntimeException(
+                                            "Unexpected type when validating query parameters");
                                 }
 
                                 @Override
                                 public Boolean visitExternal(ExternalReference _value) {
-                                    throw new SafeRuntimeException("Unexpected type when validating query parameters");
+                                    throw new ConjureRuntimeException(
+                                            "Unexpected type when validating query parameters");
                                 }
 
                                 @Override
                                 public Boolean visitUnknown(String _unknownType) {
-                                    throw new SafeRuntimeException("Unexpected type when validating query parameters");
+                                    throw new ConjureRuntimeException(
+                                            "Unexpected type when validating query parameters");
                                 }
                             }));
         }

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/FieldDefinitionValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/FieldDefinitionValidator.java
@@ -16,6 +16,7 @@
 
 package com.palantir.conjure.defs.validator;
 
+import com.palantir.conjure.exceptions.ConjureIllegalStateException;
 import com.palantir.conjure.spec.FieldDefinition;
 import com.palantir.conjure.spec.MapType;
 import com.palantir.conjure.visitor.TypeVisitor;
@@ -32,7 +33,7 @@ public final class FieldDefinitionValidator {
         if (typeDef.getType().accept(TypeVisitor.IS_MAP)) {
             MapType mapType = typeDef.getType().accept(TypeVisitor.MAP);
             if (!mapType.getKeyType().accept(TypeVisitor.IS_PRIMITIVE_OR_REFERENCE)) {
-                throw new IllegalStateException(
+                throw new ConjureIllegalStateException(
                         String.format("Complex type '%s' not allowed in map key: %s.", mapType.getKeyType(), typeDef));
             }
         }

--- a/conjure-core/src/main/java/com/palantir/conjure/exceptions/ConjureException.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/exceptions/ConjureException.java
@@ -1,0 +1,19 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.exceptions;
+
+public interface ConjureException {}

--- a/conjure-core/src/main/java/com/palantir/conjure/exceptions/ConjureIllegalArgumentException.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/exceptions/ConjureIllegalArgumentException.java
@@ -1,0 +1,23 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.exceptions;
+
+public class ConjureIllegalArgumentException extends IllegalArgumentException implements ConjureException {
+    public ConjureIllegalArgumentException(String reason) {
+        super(reason);
+    }
+}

--- a/conjure-core/src/main/java/com/palantir/conjure/exceptions/ConjureIllegalStateException.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/exceptions/ConjureIllegalStateException.java
@@ -1,0 +1,23 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.exceptions;
+
+public class ConjureIllegalStateException extends IllegalStateException implements ConjureException {
+    public ConjureIllegalStateException(String reason) {
+        super(reason);
+    }
+}

--- a/conjure-core/src/main/java/com/palantir/conjure/exceptions/ConjureRuntimeException.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/exceptions/ConjureRuntimeException.java
@@ -1,0 +1,27 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.exceptions;
+
+public class ConjureRuntimeException extends RuntimeException implements ConjureException {
+    public ConjureRuntimeException(String reason) {
+        super(reason);
+    }
+
+    public ConjureRuntimeException(String reason, Throwable cause) {
+        super(reason, cause);
+    }
+}

--- a/conjure/src/main/java/com/palantir/conjure/cli/ConjureCli.java
+++ b/conjure/src/main/java/com/palantir/conjure/cli/ConjureCli.java
@@ -30,11 +30,9 @@ import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import com.palantir.parsec.ParseException;
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import javax.annotation.Nullable;
 import picocli.CommandLine;
 import picocli.CommandLine.IExecutionExceptionHandler;
@@ -82,20 +80,11 @@ public final class ConjureCli implements Runnable {
                 throw ex;
             }
 
-            // Dedupe exceptions to ensure we don't end up in a cause loop
-            Set<Throwable> seen = new HashSet<>();
             // Unpack errors; we don't care about where in the code the error comes from: the issue is in the supplied
             // conjure code. The stack doesn't help.
-            Throwable curr = ex;
-            while (curr != null) {
-                if (seen.contains(curr)) {
-                    break;
-                }
+            Throwables.getCausalChain(ex)
+                    .forEach(exception -> commandLine.getErr().println(exception.getMessage()));
 
-                seen.add(curr);
-                commandLine.getErr().println(curr.getMessage());
-                curr = curr.getCause();
-            }
             return -1;
         }
     }

--- a/conjure/src/main/java/com/palantir/conjure/cli/ConjureCli.java
+++ b/conjure/src/main/java/com/palantir/conjure/cli/ConjureCli.java
@@ -21,9 +21,13 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Throwables;
 import com.palantir.conjure.defs.Conjure;
+import com.palantir.conjure.exceptions.ConjureException;
+import com.palantir.conjure.parser.ConjureParser.CyclicImportException;
 import com.palantir.conjure.spec.ConjureDefinition;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import com.palantir.parsec.ParseException;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
@@ -31,6 +35,8 @@ import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import picocli.CommandLine;
+import picocli.CommandLine.IExecutionExceptionHandler;
+import picocli.CommandLine.ParseResult;
 
 @CommandLine.Command(
         name = "conjure",
@@ -43,7 +49,46 @@ public final class ConjureCli implements Runnable {
             .setSerializationInclusion(JsonInclude.Include.NON_ABSENT);
 
     public static void main(String[] args) {
-        System.exit(new CommandLine(new ConjureCli()).execute(args));
+        System.exit(prepareCommand().execute(args));
+    }
+
+    @VisibleForTesting
+    static CommandLine prepareCommand() {
+        return new CommandLine(new ConjureCli()).setExecutionExceptionHandler(new ExceptionHandler());
+    }
+
+    public static final class ExceptionHandler implements IExecutionExceptionHandler {
+        @Override
+        public int handleExecutionException(Exception ex, CommandLine commandLine, ParseResult parseResult)
+                throws Exception {
+            if (ex == null) {
+                return 0;
+            }
+            // For known internal errors, continue, as they're signaling errors on the input, not in the code
+            Throwable rootCause = Throwables.getRootCause(ex);
+            if (!(rootCause instanceof ConjureException)
+                    && !(rootCause instanceof ParseException)
+                    && !(rootCause instanceof CyclicImportException)) {
+                throw ex;
+            }
+            if (!(commandLine.getCommand() instanceof ConjureCliCommand)) {
+                throw ex;
+            }
+            ConjureCliCommand cmd = commandLine.getCommand();
+            if (cmd.isVerbose()) {
+                // If the command is verbose, print the full stack trace
+                throw ex;
+            }
+
+            // Unpack errors; we don't care about where in the code the error comes from: the issue is in the supplied
+            // conjure code. The stack doesn't help.
+            Throwable curr = ex;
+            while (curr != null) {
+                commandLine.getErr().println(curr.getMessage());
+                curr = curr.getCause();
+            }
+            return -1;
+        }
     }
 
     @Override
@@ -51,12 +96,16 @@ public final class ConjureCli implements Runnable {
         CommandLine.usage(this, System.out);
     }
 
+    private interface ConjureCliCommand {
+        boolean isVerbose();
+    }
+
     @CommandLine.Command(
             name = "compile",
             description = "Generate Conjure IR from Conjure YML definitions.",
             mixinStandardHelpOptions = true,
             usageHelpWidth = 120)
-    public static final class CompileCommand implements Runnable {
+    public static final class CompileCommand implements Runnable, ConjureCliCommand {
         @CommandLine.Parameters(
                 paramLabel = "<input>",
                 description = "Path to the input conjure YML definition file, or directory containing multiple such "
@@ -66,6 +115,10 @@ public final class ConjureCli implements Runnable {
 
         @CommandLine.Parameters(paramLabel = "<output>", description = "Path to the output IR file.", index = "1")
         private String output;
+
+        @CommandLine.Option(names = "--verbose", description = "")
+        @Nullable
+        private boolean verbose;
 
         @CommandLine.Option(names = "--extensions", description = "")
         @Nullable
@@ -106,6 +159,11 @@ public final class ConjureCli implements Runnable {
                     Optional.ofNullable(extensions)
                             .map(ConjureCli::parseExtensions)
                             .orElseGet(Collections::emptyMap));
+        }
+
+        @Override
+        public boolean isVerbose() {
+            return verbose;
         }
     }
 

--- a/conjure/src/test/resources/key-error.yml
+++ b/conjure/src/test/resources/key-error.yml
@@ -1,0 +1,16 @@
+types:
+  imports:
+    ResourceIdentifier:
+      base-type: string
+      external:
+        java: com.palantir.ri.ResourceIdentifier
+
+  definitions: 
+    default-package: test.api
+    objects:
+      IllegalKey:
+        fields:
+          key: string
+      SimpleUnion:
+        union:
+          optionA: map<IllegalKey, string>

--- a/conjure/src/test/resources/simple-error.yml
+++ b/conjure/src/test/resources/simple-error.yml
@@ -1,0 +1,13 @@
+types:
+  imports:
+    ResourceIdentifier:
+      base-type: string
+      external:
+        java: com.palantir.ri.ResourceIdentifier
+
+  definitions: 
+    default-package: test.api
+    objects:     
+      SimpleObject:
+        fields:
+          stringField: UnknownType


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

Error messages can become unreadable:

<details>
<summary>Stderr before PR:</summary>

```
com.palantir.conjure.exceptions.ConjureRuntimeException: Encountered error trying to parse file 'src/test/resources/simple-error.yml'
	at com.palantir.conjure.defs.ConjureParserUtils.lambda$parseConjureDef$3(ConjureParserUtils.java:230)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at com.palantir.conjure.defs.ConjureParserUtils.parseConjureDef(ConjureParserUtils.java:201)
	at com.palantir.conjure.defs.Conjure.parse(Conjure.java:37)
	at com.palantir.conjure.cli.ConjureCli$CompileCommand.generate(ConjureCli.java:144)
	at com.palantir.conjure.cli.ConjureCli$CompileCommand.run(ConjureCli.java:138)
	at picocli.CommandLine.executeUserObject(CommandLine.java:1939)
	at picocli.CommandLine.access$1300(CommandLine.java:145)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2352)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2346)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2311)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2179)
	at picocli.CommandLine.execute(CommandLine.java:2078)
	at com.palantir.conjure.cli.ConjureCliTest.generatesCleanError_unknown(ConjureCliTest.java:148)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:64)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:564)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:54)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:69)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:33)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:220)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:53)
Caused by: com.palantir.conjure.exceptions.ConjureIllegalStateException: Unknown LocalReferenceType: TypeName{name=UnknownType}
	at com.palantir.conjure.defs.ConjureTypeParserVisitor$ByParsedRepresentationTypeNameResolver.resolveFromTypeName(ConjureTypeParserVisitor.java:83)
	at com.palantir.conjure.defs.ConjureTypeParserVisitor$ByParsedRepresentationTypeNameResolver.resolve(ConjureTypeParserVisitor.java:61)
	at com.palantir.conjure.defs.ConjureTypeParserVisitor.visitLocalReference(ConjureTypeParserVisitor.java:139)
	at com.palantir.conjure.defs.ConjureTypeParserVisitor.visitLocalReference(ConjureTypeParserVisitor.java:42)
	at com.palantir.conjure.parser.types.reference.LocalReferenceType.visit(LocalReferenceType.java:37)
	at com.palantir.conjure.defs.ConjureParserUtils.lambda$parseField$10(ConjureParserUtils.java:336)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
	at java.base/java.util.Collections$2.tryAdvance(Collections.java:4820)
	at java.base/java.util.Collections$2.forEachRemaining(Collections.java:4828)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
	at com.palantir.conjure.defs.ConjureParserUtils.parseField(ConjureParserUtils.java:343)
	at com.palantir.conjure.defs.ConjureParserUtils.parseObjectType(ConjureParserUtils.java:164)
	at com.palantir.conjure.defs.TypeDefinitionParserVisitor.visit(TypeDefinitionParserVisitor.java:56)
	at com.palantir.conjure.defs.TypeDefinitionParserVisitor.visit(TypeDefinitionParserVisitor.java:28)
	at com.palantir.conjure.parser.types.complex.ObjectTypeDefinition.visit(ObjectTypeDefinition.java:42)
	at com.palantir.conjure.defs.ConjureParserUtils.lambda$parseObjects$6(ConjureParserUtils.java:295)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
	at java.base/java.util.Collections$2.tryAdvance(Collections.java:4820)
	at java.base/java.util.Collections$2.forEachRemaining(Collections.java:4828)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
	at com.palantir.conjure.defs.ConjureParserUtils.parseObjects(ConjureParserUtils.java:296)
	at com.palantir.conjure.defs.ConjureParserUtils.lambda$parseConjureDef$3(ConjureParserUtils.java:209)
	... 40 more
```

</details>

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Clean up error messages generated from the CLI
==COMMIT_MSG==

Stderr after this PR:
```
Encountered error trying to parse file 'src/test/resources/simple-error.yml'
Unknown LocalReferenceType: TypeName{name=UnknownType}
```

Added a `--verbose` flag to still generate stacktraces.

## Possible downsides?

This PR takes a rather crude approach (explicitly tagging/whitelisting exceptions that should be collapsed). This is to ensure that actual bugs still produce stacktraces.

<!-- Please describe any way users could be negatively affected by this PR. -->

