### PR TITLE
Cleanup duplicate name error

### DIFF
--- a/changelog/@unreleased/pr-874.v2.yml
+++ b/changelog/@unreleased/pr-874.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Clean up duplicate name error message in CLI.
+  links:
+  - https://github.com/palantir/conjure/pull/874

--- a/conjure/src/main/java/com/palantir/conjure/cli/ConjureCli.java
+++ b/conjure/src/main/java/com/palantir/conjure/cli/ConjureCli.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
+import com.google.common.base.VerifyException;
 import com.palantir.conjure.defs.Conjure;
 import com.palantir.conjure.exceptions.ConjureException;
 import com.palantir.conjure.parser.ConjureParser.CyclicImportException;
@@ -68,7 +69,8 @@ public final class ConjureCli implements Runnable {
             Throwable rootCause = Throwables.getRootCause(ex);
             if (!(rootCause instanceof ConjureException)
                     && !(rootCause instanceof ParseException)
-                    && !(rootCause instanceof CyclicImportException)) {
+                    && !(rootCause instanceof CyclicImportException)
+                    && !(rootCause instanceof VerifyException)) {
                 throw ex;
             }
             if (!(commandLine.getCommand() instanceof ConjureCliCommand)) {

--- a/conjure/src/main/java/com/palantir/conjure/cli/ConjureCli.java
+++ b/conjure/src/main/java/com/palantir/conjure/cli/ConjureCli.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
-import com.google.common.base.VerifyException;
 import com.palantir.conjure.defs.Conjure;
 import com.palantir.conjure.exceptions.ConjureException;
 import com.palantir.conjure.parser.ConjureParser.CyclicImportException;
@@ -69,8 +68,7 @@ public final class ConjureCli implements Runnable {
             Throwable rootCause = Throwables.getRootCause(ex);
             if (!(rootCause instanceof ConjureException)
                     && !(rootCause instanceof ParseException)
-                    && !(rootCause instanceof CyclicImportException)
-                    && !(rootCause instanceof VerifyException)) {
+                    && !(rootCause instanceof CyclicImportException)) {
                 throw ex;
             }
             if (!(commandLine.getCommand() instanceof ConjureCliCommand)) {

--- a/conjure/src/test/java/com/palantir/conjure/cli/ConjureCliTest.java
+++ b/conjure/src/test/java/com/palantir/conjure/cli/ConjureCliTest.java
@@ -167,6 +167,24 @@ public final class ConjureCliTest {
     }
 
     @Test
+    public void generatesCleanError_unique_name() {
+        String[] args = {"compile", "src/test/resources/unique-name-error", outputFile.getAbsolutePath()};
+
+        StringWriter stringWriter = new StringWriter();
+        PrintWriter printWriter = new PrintWriter(stringWriter);
+        ConjureCli.prepareCommand().setErr(printWriter).execute(args);
+        printWriter.flush();
+        assertThat(stringWriter.toString())
+                .isEqualTo("Type, error, and service names must be unique across locally defined and imported "
+                        + "types/errors:\nFound duplicate name: test.api.ConflictingName\n"
+                        + "Known names:\n"
+                        + " - test.api.UniqueName\n"
+                        + " - test.api.UniqueName2\n"
+                        + " - test.api.ConflictingName\n");
+        assertThat(outputFile.isFile()).isFalse();
+    }
+
+    @Test
     public void throwsWhenInvalidDefinition() throws Exception {
         CliConfiguration configuration = CliConfiguration.builder()
                 .inputFiles(ImmutableList.of(inputFile))

--- a/conjure/src/test/java/com/palantir/conjure/cli/ConjureCliTest.java
+++ b/conjure/src/test/java/com/palantir/conjure/cli/ConjureCliTest.java
@@ -136,7 +136,7 @@ public final class ConjureCliTest {
                 .outputIrFile(outputFile)
                 .build();
         ConjureCli.CompileCommand.generate(configuration);
-        assertThat(outputFile.isFile()).isTrue();
+        assertThat(outputFile).exists();
     }
 
     @Test
@@ -150,7 +150,7 @@ public final class ConjureCliTest {
         assertThat(stringWriter.toString())
                 .isEqualTo("Encountered error trying to parse file 'src/test/resources/simple-error.yml'\n"
                         + "Unknown LocalReferenceType: TypeName{name=UnknownType}\n");
-        assertThat(outputFile.isFile()).isFalse();
+        assertThat(outputFile).doesNotExist();
     }
 
     @Test
@@ -163,7 +163,7 @@ public final class ConjureCliTest {
         printWriter.flush();
         assertThat(stringWriter.toString().trim())
                 .isEqualTo("Illegal map key found in union SimpleUnion in member optionA");
-        assertThat(outputFile.isFile()).isFalse();
+        assertThat(outputFile).doesNotExist();
     }
 
     @Test
@@ -182,7 +182,7 @@ public final class ConjureCliTest {
                         + " - test.api.UniqueName\n"
                         + " - test.api.UniqueName2\n"
                         + " - test.api.ConflictingName\n");
-        assertThat(outputFile.isFile()).isFalse();
+        assertThat(outputFile).doesNotExist();
     }
 
     @Test

--- a/conjure/src/test/java/com/palantir/conjure/cli/ConjureCliTest.java
+++ b/conjure/src/test/java/com/palantir/conjure/cli/ConjureCliTest.java
@@ -175,8 +175,9 @@ public final class ConjureCliTest {
         ConjureCli.prepareCommand().setErr(printWriter).execute(args);
         printWriter.flush();
         assertThat(stringWriter.toString())
-                .isEqualTo("Type, error, and service names must be unique across locally defined and imported "
-                        + "types/errors:\nFound duplicate name: test.api.ConflictingName\n"
+                .isEqualTo("Type, error, and service names must be unique across locally defined and "
+                        + "imported types/errors:\n"
+                        + "Found duplicate name: test.api.ConflictingName\n"
                         + "Known names:\n"
                         + " - test.api.UniqueName\n"
                         + " - test.api.UniqueName2\n"

--- a/conjure/src/test/resources/unique-name-error/unique-name-error-2.yml
+++ b/conjure/src/test/resources/unique-name-error/unique-name-error-2.yml
@@ -1,0 +1,16 @@
+types:
+  imports:
+    ResourceIdentifier:
+      base-type: string
+      external:
+        java: com.palantir.ri.ResourceIdentifier
+
+  definitions:
+    default-package: test.api
+    objects:
+      UniqueName2:
+        fields: {}
+      ConflictingName:
+        docs: This name conflicts with the one in unique-name-error.yml
+        union:
+          optionA: string

--- a/conjure/src/test/resources/unique-name-error/unique-name-error.yml
+++ b/conjure/src/test/resources/unique-name-error/unique-name-error.yml
@@ -1,0 +1,16 @@
+types:
+  imports:
+    ResourceIdentifier:
+      base-type: string
+      external:
+        java: com.palantir.ri.ResourceIdentifier
+
+  definitions:
+    default-package: test.api
+    objects:
+      UniqueName:
+        fields: {}
+      ConflictingName:
+        docs: This name conflicts with the one in unique-name-error-2.yml
+        union:
+          optionA: string


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
<details>
<summary>Before</summary>

Note that in real cases this is quite a bit more obnoxious, as the first list contains all types that have been processed until then. In large code-bases this can be substantial.

```
com.google.common.base.VerifyException: Type, error, and service names must be unique across locally defined and imported types/errors: [TypeName{name: UniqueName, package: test.api}, TypeName{name: UniqueName2, package: test.api}, TypeName{name: ConflictingName, package: test.api}]
TypeName{name: ConflictingName, package: test.api}
	at com.google.common.base.Verify.verify(Verify.java:424)
	at com.palantir.conjure.defs.validator.ConjureDefinitionValidator$UniqueNamesValidator.verifyNameIsUnique(ConjureDefinitionValidator.java:117)
	at com.palantir.conjure.defs.validator.ConjureDefinitionValidator$UniqueNamesValidator.lambda$validate$0(ConjureDefinitionValidator.java:110)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.Collections$UnmodifiableCollection.forEach(Collections.java:1087)
	at com.palantir.conjure.defs.validator.ConjureDefinitionValidator$UniqueNamesValidator.validate(ConjureDefinitionValidator.java:110)
	at com.palantir.conjure.defs.validator.ConjureDefinitionValidator$UniqueNamesValidator.validate(ConjureDefinitionValidator.java:103)
	at com.palantir.conjure.defs.validator.ConjureDefinitionValidator.validate(ConjureDefinitionValidator.java:73)
	at com.palantir.conjure.defs.validator.ConjureDefinitionValidator.validate(ConjureDefinitionValidator.java:50)
	at com.palantir.conjure.defs.validator.ConjureDefinitionValidator.validateAll(ConjureDefinitionValidator.java:61)
	at com.palantir.conjure.defs.ConjureParserUtils.parseConjureDef(ConjureParserUtils.java:241)
	at com.palantir.conjure.defs.Conjure.parse(Conjure.java:37)
	at com.palantir.conjure.cli.ConjureCli$CompileCommand.generate(ConjureCli.java:141)
	at com.palantir.conjure.cli.ConjureCli$CompileCommand.run(ConjureCli.java:135)
	at picocli.CommandLine.executeUserObject(CommandLine.java:1939)
	at picocli.CommandLine.access$1300(CommandLine.java:145)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2352)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2346)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2311)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2179)
	at picocli.CommandLine.execute(CommandLine.java:2078)
	at com.palantir.conjure.cli.ConjureCliTest.generatesCleanError_unique_name(ConjureCliTest.java:175)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:64)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:564)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:54)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:69)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:33)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:220)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:53)
```
</details

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Clean up duplicate name error message in CLI.
==COMMIT_MSG==

After:
```
Type, error, and service names must be unique across locally defined and imported types/errors:
Found duplicate name: test.api.ConflictingName
Known names:
 - test.api.UniqueName
 - test.api.UniqueName2
 - test.api.ConflictingName
```

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

