### PR TITLE
Clean up JSON mapping errors

### DIFF
--- a/changelog/@unreleased/pr-875.v2.yml
+++ b/changelog/@unreleased/pr-875.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Improve readability of JSON mapping errors.
+  links:
+  - https://github.com/palantir/conjure/pull/875

--- a/changelog/@unreleased/pr-875.v2.yml
+++ b/changelog/@unreleased/pr-875.v2.yml
@@ -1,5 +1,5 @@
-type: improvement
-improvement:
+type: fix
+fix:
   description: Improve readability of JSON mapping errors.
   links:
   - https://github.com/palantir/conjure/pull/875

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/ConjureParser.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/ConjureParser.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.annotations.VisibleForTesting;
+import com.palantir.conjure.exceptions.ConjureRuntimeException;
 import com.palantir.conjure.parser.types.TypesDefinition;
 import com.palantir.conjure.parser.types.names.Namespace;
 import com.palantir.conjure.parser.types.reference.ConjureImports;
@@ -130,7 +131,7 @@ public final class ConjureParser {
                                 .build())
                         .build();
             } catch (IOException e) {
-                throw new RuntimeException(e);
+                throw new ConjureRuntimeException(String.format("Error while parsing %s:", file), e);
             }
         }
 

--- a/conjure-core/src/test/java/com/palantir/conjure/parser/ConjureParserTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/parser/ConjureParserTest.java
@@ -59,6 +59,7 @@ public class ConjureParserTest {
     @Test
     public void duplicate_keys_fail_to_parse() throws Exception {
         assertThatThrownBy(() -> ConjureParser.parse(new File("src/test/resources/duplicate-keys.yml")))
+                .getRootCause()
                 .hasMessageContaining("Duplicate field 'services'");
     }
 

--- a/conjure/src/test/java/com/palantir/conjure/cli/ConjureCliTest.java
+++ b/conjure/src/test/java/com/palantir/conjure/cli/ConjureCliTest.java
@@ -186,6 +186,22 @@ public final class ConjureCliTest {
     }
 
     @Test
+    public void generatesCleanError_invalid_json() {
+        String[] args = {"compile", "src/test/resources/invalid-json.yml", outputFile.getAbsolutePath()};
+
+        StringWriter stringWriter = new StringWriter();
+        PrintWriter printWriter = new PrintWriter(stringWriter);
+        ConjureCli.prepareCommand().setErr(printWriter).execute(args);
+        printWriter.flush();
+        assertThat(stringWriter.toString())
+                .isEqualTo("Error while parsing src/test/resources/invalid-json.yml:\n"
+                        + "Cannot build FieldDefinition, some of required attributes are not set [type]\n"
+                        + "  @ types -> definitions -> objects -> InvalidJson -> union -> optionA\n"
+                        + "Cannot build FieldDefinition, some of required attributes are not set [type]\n");
+        assertThat(outputFile).doesNotExist();
+    }
+
+    @Test
     public void throwsWhenInvalidDefinition() throws Exception {
         CliConfiguration configuration = CliConfiguration.builder()
                 .inputFiles(ImmutableList.of(inputFile))

--- a/conjure/src/test/java/com/palantir/conjure/cli/ConjureCliTest.java
+++ b/conjure/src/test/java/com/palantir/conjure/cli/ConjureCliTest.java
@@ -19,6 +19,7 @@ package com.palantir.conjure.cli;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.google.common.collect.ImmutableList;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.io.File;
@@ -208,7 +209,7 @@ public final class ConjureCliTest {
                 .outputIrFile(folder.newFolder())
                 .build();
         assertThatThrownBy(() -> ConjureCli.CompileCommand.generate(configuration))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("MismatchedInputException");
+                .getRootCause()
+                .isInstanceOf(MismatchedInputException.class);
     }
 }

--- a/conjure/src/test/resources/invalid-json.yml
+++ b/conjure/src/test/resources/invalid-json.yml
@@ -1,0 +1,13 @@
+types:
+  imports:
+    ResourceIdentifier:
+      base-type: string
+      external:
+        java: com.palantir.ri.ResourceIdentifier
+
+  definitions: 
+    default-package: test.api
+    objects:
+      InvalidJson:
+        union:
+          optionA: { }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

<details>
<summary>Before</summary>

Note the absence of a reference to which file failed.

```
java.lang.RuntimeException: com.fasterxml.jackson.databind.JsonMappingException: Cannot build FieldDefinition, some of required attributes are not set [type] (through reference chain: com.palantir.conjure.parser.ImmutableConjureSourceFile$Json["types"]->com.palantir.conjure.parser.types.ImmutableTypesDefinition$Json["definitions"]->com.palantir.conjure.parser.types.ImmutableNamedTypesDefinition$Json["objects"]->java.util.LinkedHashMap["InvalidJson"]->com.palantir.conjure.parser.types.complex.ImmutableUnionTypeDefinition$Json["union"]->java.util.LinkedHashMap["optionA"])
	at com.palantir.conjure.parser.ConjureParser$RecursiveParser.parseInternal(ConjureParser.java:133)
	at com.palantir.conjure.parser.ConjureParser$RecursiveParser.parse(ConjureParser.java:107)
	at com.palantir.conjure.parser.ConjureParser.parseAnnotated(ConjureParser.java:77)
	at com.palantir.conjure.parser.ConjureParser.lambda$parseAnnotated$0(ConjureParser.java:72)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
	at java.base/java.util.Collections$2.tryAdvance(Collections.java:4820)
	at java.base/java.util.Collections$2.forEachRemaining(Collections.java:4828)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
	at com.palantir.conjure.parser.ConjureParser.parseAnnotated(ConjureParser.java:72)
	at com.palantir.conjure.defs.Conjure.parse(Conjure.java:36)
	at com.palantir.conjure.cli.ConjureCli$CompileCommand.generate(ConjureCli.java:141)
	at com.palantir.conjure.cli.ConjureCli$CompileCommand.run(ConjureCli.java:135)
	at picocli.CommandLine.executeUserObject(CommandLine.java:1939)
	at picocli.CommandLine.access$1300(CommandLine.java:145)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2352)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2346)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2311)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2179)
	at picocli.CommandLine.execute(CommandLine.java:2078)
	at com.palantir.conjure.cli.ConjureCliTest.generatesCleanError_invalid_json(ConjureCliTest.java:194)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:64)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:564)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:54)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:69)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:33)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:220)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:53)
Caused by: com.fasterxml.jackson.databind.JsonMappingException: Cannot build FieldDefinition, some of required attributes are not set [type] (through reference chain: com.palantir.conjure.parser.ImmutableConjureSourceFile$Json["types"]->com.palantir.conjure.parser.types.ImmutableTypesDefinition$Json["definitions"]->com.palantir.conjure.parser.types.ImmutableNamedTypesDefinition$Json["objects"]->java.util.LinkedHashMap["InvalidJson"]->com.palantir.conjure.parser.types.complex.ImmutableUnionTypeDefinition$Json["union"]->java.util.LinkedHashMap["optionA"])
	at com.fasterxml.jackson.databind.JsonMappingException.wrapWithPath(JsonMappingException.java:390)
	at com.fasterxml.jackson.databind.JsonMappingException.wrapWithPath(JsonMappingException.java:349)
	at com.fasterxml.jackson.databind.deser.std.ContainerDeserializerBase.wrapAndThrow(ContainerDeserializerBase.java:190)
	at com.fasterxml.jackson.databind.deser.std.MapDeserializer._readAndBind(MapDeserializer.java:559)
	at com.fasterxml.jackson.databind.deser.std.MapDeserializer.deserialize(MapDeserializer.java:440)
	at com.fasterxml.jackson.databind.deser.std.MapDeserializer.deserialize(MapDeserializer.java:32)
	at com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeAndSet(MethodProperty.java:129)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:324)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeOther(BeanDeserializer.java:225)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:197)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromObjectUsingNonDefault(BeanDeserializerBase.java:1398)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:362)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:195)
	at com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:322)
	at com.fasterxml.jackson.databind.ObjectMapper._readValue(ObjectMapper.java:4569)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:2798)
	at com.fasterxml.jackson.databind.ObjectMapper.treeToValue(ObjectMapper.java:3261)
	at com.palantir.conjure.parser.types.complex.UnionTypeDefinition.fromJson(UnionTypeDefinition.java:46)
	at com.palantir.conjure.parser.types.BaseObjectTypeDefinition$BaseObjectTypeDefinitionDeserializer.deserialize(BaseObjectTypeDefinition.java:58)
	at com.palantir.conjure.parser.types.BaseObjectTypeDefinition$BaseObjectTypeDefinitionDeserializer.deserialize(BaseObjectTypeDefinition.java:46)
	at com.fasterxml.jackson.databind.deser.std.MapDeserializer._readAndBind(MapDeserializer.java:547)
	at com.fasterxml.jackson.databind.deser.std.MapDeserializer.deserialize(MapDeserializer.java:440)
	at com.fasterxml.jackson.databind.deser.std.MapDeserializer.deserialize(MapDeserializer.java:32)
	at com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeAndSet(MethodProperty.java:129)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:324)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeOther(BeanDeserializer.java:225)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:197)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromObjectUsingNonDefault(BeanDeserializerBase.java:1398)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:362)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:195)
	at com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeAndSet(MethodProperty.java:129)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:324)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeOther(BeanDeserializer.java:225)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:197)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromObjectUsingNonDefault(BeanDeserializerBase.java:1398)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:362)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:195)
	at com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeAndSet(MethodProperty.java:129)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:324)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeOther(BeanDeserializer.java:225)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:197)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromObjectUsingNonDefault(BeanDeserializerBase.java:1398)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:362)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:195)
	at com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:322)
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4593)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3413)
	at com.palantir.conjure.parser.ConjureParser$RecursiveParser.parseInternal(ConjureParser.java:122)
	... 50 more
Caused by: java.lang.IllegalStateException: Cannot build FieldDefinition, some of required attributes are not set [type]
	at com.palantir.conjure.parser.types.complex.ImmutableFieldDefinition$Builder.build(ImmutableFieldDefinition.java:375)
	at com.palantir.conjure.parser.types.complex.ImmutableFieldDefinition.fromJson(ImmutableFieldDefinition.java:233)
	at com.palantir.conjure.parser.types.complex.FieldDefinition$FieldDefinitionDeserializer.deserialize(FieldDefinition.java:61)
	at com.palantir.conjure.parser.types.complex.FieldDefinition$FieldDefinitionDeserializer.deserialize(FieldDefinition.java:47)
	at com.fasterxml.jackson.databind.deser.std.MapDeserializer._readAndBind(MapDeserializer.java:547)
	... 94 more
```

</details>

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Improve readability of JSON mapping errors.
==COMMIT_MSG==

```
Error while parsing src/test/resources/invalid-json.yml:
Cannot build FieldDefinition, some of required attributes are not set [type]
  @ types -> definitions -> objects -> InvalidJson -> union -> optionA
Cannot build FieldDefinition, some of required attributes are not set [type]
```

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

