### PR TITLE
fix #974: The Conjure parser supports a `--strict` flag

### DIFF
--- a/changelog/@unreleased/pr-975.v2.yml
+++ b/changelog/@unreleased/pr-975.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: 'fix #974: The Conjure parser supports a `--strict` flag to fail on
+    non-camel-case fields'
+  links:
+  - https://github.com/palantir/conjure/pull/975

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/Conjure.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/Conjure.java
@@ -33,8 +33,16 @@ public final class Conjure {
      * Deserializes {@link ConjureDefinition} from their YAML representations in the given files.
      */
     public static ConjureDefinition parse(Collection<File> files) {
+        return parse(files, ConjureOptions.builder().strict(false).build());
+    }
+
+    /**
+     * Deserializes {@link ConjureDefinition} from their YAML representations in the given files, using the provided
+     * {@link ConjureOptions}.
+     */
+    public static ConjureDefinition parse(Collection<File> files, ConjureOptions options) {
         Map<String, AnnotatedConjureSourceFile> sourceFiles = ConjureParser.parseAnnotated(files);
-        ConjureDefinition ir = ConjureParserUtils.parseConjureDef(sourceFiles);
+        ConjureDefinition ir = ConjureParserUtils.parseConjureDef(sourceFiles, options);
         return NormalizeDefinition.normalize(ir);
     }
 }

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureOptions.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureOptions.java
@@ -14,16 +14,19 @@
  * limitations under the License.
  */
 
-package com.palantir.conjure.defs.validator;
+package com.palantir.conjure.defs;
 
-import com.palantir.conjure.defs.ConjureOptions;
-import com.palantir.conjure.visitor.DealiasingTypeVisitor;
+import org.immutables.value.Value;
 
-@com.google.errorprone.annotations.Immutable
-public interface ConjureContextualValidator<T> {
-    /**
-     * Validates that the provided definition is valid according to Conjure rules. Throws an exception if the
-     * provided definition is invalid.
-     */
-    void validate(T definition, DealiasingTypeVisitor dealiasingTypeVisitor, ConjureOptions options);
+@ConjureImmutablesStyle
+@Value.Immutable
+public interface ConjureOptions {
+
+    boolean strict();
+
+    static Builder builder() {
+        return new Builder();
+    }
+
+    class Builder extends ImmutableConjureOptions.Builder {}
 }

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/TypeDefinitionParserVisitor.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/TypeDefinitionParserVisitor.java
@@ -30,14 +30,17 @@ public final class TypeDefinitionParserVisitor implements TypeDefinitionVisitor<
     private final String name;
     private final Optional<String> defaultPackage;
     private final ConjureTypeParserVisitor.ReferenceTypeResolver typeResolver;
+    private final ConjureOptions options;
 
     public TypeDefinitionParserVisitor(
             String typeName,
             Optional<String> defaultPackage,
-            ConjureTypeParserVisitor.ReferenceTypeResolver typeResolver) {
+            ConjureTypeParserVisitor.ReferenceTypeResolver typeResolver,
+            ConjureOptions options) {
         this.name = typeName;
         this.defaultPackage = defaultPackage;
         this.typeResolver = typeResolver;
+        this.options = options;
     }
 
     @Override
@@ -48,18 +51,19 @@ public final class TypeDefinitionParserVisitor implements TypeDefinitionVisitor<
 
     @Override
     public TypeDefinition visit(EnumTypeDefinition def) {
-        return ConjureParserUtils.parseEnumType(ConjureParserUtils.createTypeName(name, def, defaultPackage), def);
+        return ConjureParserUtils.parseEnumType(
+                ConjureParserUtils.createTypeName(name, def, defaultPackage), def, options);
     }
 
     @Override
     public TypeDefinition visit(ObjectTypeDefinition def) {
         return ConjureParserUtils.parseObjectType(
-                ConjureParserUtils.createTypeName(name, def, defaultPackage), def, typeResolver);
+                ConjureParserUtils.createTypeName(name, def, defaultPackage), def, typeResolver, options);
     }
 
     @Override
     public TypeDefinition visit(UnionTypeDefinition def) {
         return ConjureParserUtils.parseUnionType(
-                ConjureParserUtils.createTypeName(name, def, defaultPackage), def, typeResolver);
+                ConjureParserUtils.createTypeName(name, def, defaultPackage), def, typeResolver, options);
     }
 }

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/ConjureDefinitionValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/ConjureDefinitionValidator.java
@@ -22,6 +22,7 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.palantir.conjure.defs.Conjure;
+import com.palantir.conjure.defs.ConjureOptions;
 import com.palantir.conjure.exceptions.ConjureIllegalStateException;
 import com.palantir.conjure.spec.AliasDefinition;
 import com.palantir.conjure.spec.ConjureDefinition;
@@ -55,9 +56,9 @@ public enum ConjureDefinitionValidator implements ConjureValidator<ConjureDefini
     NO_NESTED_OPTIONAL(new NoNestedOptionalValidator()),
     ILLEGAL_MAP_KEYS(new IllegalMapKeyValidator());
 
-    public static void validateAll(ConjureDefinition definition) {
+    public static void validateAll(ConjureDefinition definition, ConjureOptions options) {
         for (ConjureValidator<ConjureDefinition> validator : values()) {
-            validator.validate(definition);
+            validator.validate(definition, options);
         }
     }
 
@@ -68,14 +69,14 @@ public enum ConjureDefinitionValidator implements ConjureValidator<ConjureDefini
     }
 
     @Override
-    public void validate(ConjureDefinition definition) {
-        validator.validate(definition);
+    public void validate(ConjureDefinition definition, ConjureOptions options) {
+        validator.validate(definition, options);
     }
 
     @com.google.errorprone.annotations.Immutable
     private static final class UniqueServiceNamesValidator implements ConjureValidator<ConjureDefinition> {
         @Override
-        public void validate(ConjureDefinition definition) {
+        public void validate(ConjureDefinition definition, ConjureOptions _options) {
             Set<String> seenNames = new HashSet<>();
             definition.getServices().forEach(service -> {
                 boolean isNewName = seenNames.add(service.getServiceName().getName());
@@ -90,7 +91,7 @@ public enum ConjureDefinitionValidator implements ConjureValidator<ConjureDefini
     @com.google.errorprone.annotations.Immutable
     private static final class IllegalVersionValidator implements ConjureValidator<ConjureDefinition> {
         @Override
-        public void validate(ConjureDefinition definition) {
+        public void validate(ConjureDefinition definition, ConjureOptions _options) {
             Preconditions.checkState(
                     definition.getVersion() == Conjure.SUPPORTED_IR_VERSION,
                     "Definition version must be %s, but version %s is provided instead.",
@@ -102,7 +103,7 @@ public enum ConjureDefinitionValidator implements ConjureValidator<ConjureDefini
     @com.google.errorprone.annotations.Immutable
     private static final class UniqueNamesValidator implements ConjureValidator<ConjureDefinition> {
         @Override
-        public void validate(ConjureDefinition definition) {
+        public void validate(ConjureDefinition definition, ConjureOptions _options) {
             Set<TypeName> seenNames = new HashSet<>();
             definition
                     .getTypes()
@@ -131,7 +132,7 @@ public enum ConjureDefinitionValidator implements ConjureValidator<ConjureDefini
     @com.google.errorprone.annotations.Immutable
     private static final class NoRecursiveTypesValidator implements ConjureValidator<ConjureDefinition> {
         @Override
-        public void validate(ConjureDefinition definition) {
+        public void validate(ConjureDefinition definition, ConjureOptions _options) {
             // create mapping from object type name -> names of reference types that are fields of that type
             Multimap<TypeName, TypeName> typeToRefFields = HashMultimap.create();
 
@@ -188,7 +189,7 @@ public enum ConjureDefinitionValidator implements ConjureValidator<ConjureDefini
     @com.google.errorprone.annotations.Immutable
     public static final class NoNestedOptionalValidator implements ConjureValidator<ConjureDefinition> {
         @Override
-        public void validate(ConjureDefinition definition) {
+        public void validate(ConjureDefinition definition, ConjureOptions _options) {
             // create mapping for resolving reference types during validation
             Map<TypeName, TypeDefinition> definitionMap = definition.getTypes().stream()
                     .collect(Collectors.toMap(entry -> entry.accept(TypeDefinitionVisitor.TYPE_NAME), entry -> entry));
@@ -308,7 +309,7 @@ public enum ConjureDefinitionValidator implements ConjureValidator<ConjureDefini
     private static final class IllegalMapKeyValidator implements ConjureValidator<ConjureDefinition> {
 
         @Override
-        public void validate(ConjureDefinition definition) {
+        public void validate(ConjureDefinition definition, ConjureOptions _options) {
             // create mapping for resolving reference types during validation
             Map<TypeName, TypeDefinition> definitionMap = definition.getTypes().stream()
                     .collect(Collectors.toMap(entry -> entry.accept(TypeDefinitionVisitor.TYPE_NAME), entry -> entry));

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/ConjureValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/ConjureValidator.java
@@ -16,11 +16,13 @@
 
 package com.palantir.conjure.defs.validator;
 
+import com.palantir.conjure.defs.ConjureOptions;
+
 @com.google.errorprone.annotations.Immutable
 public interface ConjureValidator<T> {
     /**
      * Validates that the provided definition is valid according to Conjure rules. Throws an exception if the
      * provided definition is invalid.
      */
-    void validate(T definition);
+    void validate(T definition, ConjureOptions options);
 }

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/EnumDefinitionValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/EnumDefinitionValidator.java
@@ -17,6 +17,7 @@
 package com.palantir.conjure.defs.validator;
 
 import com.google.common.base.Preconditions;
+import com.palantir.conjure.defs.ConjureOptions;
 import com.palantir.conjure.parser.types.complex.EnumTypeDefinition;
 import com.palantir.conjure.spec.EnumDefinition;
 import com.palantir.conjure.spec.EnumValueDefinition;
@@ -28,9 +29,9 @@ public enum EnumDefinitionValidator implements ConjureValidator<EnumDefinition> 
     UniqueEnumValues(new UniqueEnumValuesValidator()),
     ValuesValidator(new ValuesValidator());
 
-    public static void validateAll(EnumDefinition definition) {
+    public static void validateAll(EnumDefinition definition, ConjureOptions options) {
         for (EnumDefinitionValidator validator : values()) {
-            validator.validate(definition);
+            validator.validate(definition, options);
         }
     }
 
@@ -41,15 +42,15 @@ public enum EnumDefinitionValidator implements ConjureValidator<EnumDefinition> 
     }
 
     @Override
-    public void validate(EnumDefinition definition) {
-        validator.validate(definition);
+    public void validate(EnumDefinition definition, ConjureOptions options) {
+        validator.validate(definition, options);
     }
 
     @com.google.errorprone.annotations.Immutable
     private static final class UniqueEnumValuesValidator implements ConjureValidator<EnumDefinition> {
 
         @Override
-        public void validate(EnumDefinition definition) {
+        public void validate(EnumDefinition definition, ConjureOptions _options) {
             Set<String> enumValues = new HashSet<>();
             for (EnumValueDefinition valueDef : definition.getValues()) {
                 boolean unseen = enumValues.add(valueDef.getValue());
@@ -66,8 +67,8 @@ public enum EnumDefinitionValidator implements ConjureValidator<EnumDefinition> 
     private static final class ValuesValidator implements ConjureValidator<EnumDefinition> {
 
         @Override
-        public void validate(EnumDefinition definition) {
-            definition.getValues().forEach(EnumValueDefinitionValidator::validateAll);
+        public void validate(EnumDefinition definition, ConjureOptions options) {
+            definition.getValues().forEach(def -> EnumValueDefinitionValidator.validateAll(def, options));
         }
     }
 }

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/EnumValueDefinitionValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/EnumValueDefinitionValidator.java
@@ -17,6 +17,7 @@
 package com.palantir.conjure.defs.validator;
 
 import com.google.common.base.Preconditions;
+import com.palantir.conjure.defs.ConjureOptions;
 import com.palantir.conjure.spec.EnumValueDefinition;
 import java.util.regex.Pattern;
 
@@ -25,9 +26,9 @@ public enum EnumValueDefinitionValidator implements ConjureValidator<EnumValueDe
     UnknownValueNotUsed(new UnknownValueNotUsedValidator()),
     Format(new FormatValidator());
 
-    public static void validateAll(EnumValueDefinition definition) {
+    public static void validateAll(EnumValueDefinition definition, ConjureOptions options) {
         for (ConjureValidator<EnumValueDefinition> validator : values()) {
-            validator.validate(definition);
+            validator.validate(definition, options);
         }
     }
 
@@ -38,15 +39,15 @@ public enum EnumValueDefinitionValidator implements ConjureValidator<EnumValueDe
     }
 
     @Override
-    public void validate(EnumValueDefinition definition) {
-        validator.validate(definition);
+    public void validate(EnumValueDefinition definition, ConjureOptions options) {
+        validator.validate(definition, options);
     }
 
     @com.google.errorprone.annotations.Immutable
     private static final class UnknownValueNotUsedValidator implements ConjureValidator<EnumValueDefinition> {
 
         @Override
-        public void validate(EnumValueDefinition definition) {
+        public void validate(EnumValueDefinition definition, ConjureOptions _options) {
             Preconditions.checkArgument(
                     !definition.getValue().equalsIgnoreCase("UNKNOWN"),
                     "UNKNOWN is a reserved enumeration value and cannot be used in an %s",
@@ -59,7 +60,7 @@ public enum EnumValueDefinitionValidator implements ConjureValidator<EnumValueDe
         private static final Pattern REQUIRED_FORMAT = Pattern.compile("[A-Z][A-Z0-9]*(_[A-Z0-9]+)*");
 
         @Override
-        public void validate(EnumValueDefinition definition) {
+        public void validate(EnumValueDefinition definition, ConjureOptions _options) {
             Preconditions.checkArgument(
                     REQUIRED_FORMAT.matcher(definition.getValue()).matches(),
                     "Enumeration values must match format %s: %s",

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/ErrorDefinitionValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/ErrorDefinitionValidator.java
@@ -16,6 +16,7 @@
 
 package com.palantir.conjure.defs.validator;
 
+import com.palantir.conjure.defs.ConjureOptions;
 import com.palantir.conjure.spec.ErrorDefinition;
 import com.palantir.conjure.spec.FieldDefinition;
 import java.util.stream.Collectors;
@@ -28,10 +29,11 @@ public final class ErrorDefinitionValidator {
     private static final UniqueFieldNamesValidator UNIQUE_FIELD_NAMES_VALIDATOR =
             new UniqueFieldNamesValidator(ErrorDefinition.class);
 
-    public static void validate(ErrorDefinition definition) {
+    public static void validate(ErrorDefinition definition, ConjureOptions options) {
         UNIQUE_FIELD_NAMES_VALIDATOR.validate(
                 Stream.concat(definition.getSafeArgs().stream(), definition.getUnsafeArgs().stream())
                         .map(FieldDefinition::getFieldName)
-                        .collect(Collectors.toSet()));
+                        .collect(Collectors.toSet()),
+                options);
     }
 }

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/FieldNameValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/FieldNameValidator.java
@@ -43,8 +43,13 @@ public final class FieldNameValidator {
         return FieldName.of(nameCase(fieldName).convertTo(fieldName.get(), targetCase));
     }
 
-    @SuppressWarnings("Slf4jLogsafeArgs")
+    @Deprecated
     public static void validate(FieldName fieldName) {
+        validate(fieldName, false);
+    }
+
+    @SuppressWarnings({"Slf4jLogsafeArgs", "Slf4jConstantLogMessage"})
+    public static void validate(FieldName fieldName, boolean strict) {
         Preconditions.checkArgument(
                 CaseConverter.CAMEL_CASE_PATTERN.matcher(fieldName.get()).matches()
                         || CaseConverter.KEBAB_CASE_PATTERN
@@ -58,11 +63,15 @@ public final class FieldNameValidator {
                 Arrays.toString(CaseConverter.Case.values()));
 
         if (!CaseConverter.CAMEL_CASE_PATTERN.matcher(fieldName.get()).matches()) {
-            log.warn(
-                    "{} should be specified in lowerCamelCase. kebab-case and snake_case are supported for "
-                            + "legacy endpoints only: {}",
-                    FieldName.class,
-                    fieldName.get());
+            String message = String.format(
+                    "%s should be specified in lowerCamelCase. kebab-case and snake_case are "
+                            + "supported for legacy endpoints only: %s",
+                    FieldName.class, fieldName.get());
+            if (strict) {
+                throw new IllegalArgumentException(message);
+            } else {
+                log.warn(message);
+            }
         }
     }
 

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/ObjectDefinitionValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/ObjectDefinitionValidator.java
@@ -16,6 +16,7 @@
 
 package com.palantir.conjure.defs.validator;
 
+import com.palantir.conjure.defs.ConjureOptions;
 import com.palantir.conjure.spec.FieldDefinition;
 import com.palantir.conjure.spec.ObjectDefinition;
 import java.util.stream.Collectors;
@@ -27,9 +28,15 @@ public final class ObjectDefinitionValidator {
     private static final UniqueFieldNamesValidator UNIQUE_FIELD_NAMES_VALIDATOR =
             new UniqueFieldNamesValidator(ObjectDefinition.class);
 
-    public static void validate(ObjectDefinition definition) {
-        UNIQUE_FIELD_NAMES_VALIDATOR.validate(definition.getFields().stream()
-                .map(FieldDefinition::getFieldName)
-                .collect(Collectors.toSet()));
+    public static void validate(ObjectDefinition definition, ConjureOptions options) {
+        UNIQUE_FIELD_NAMES_VALIDATOR.validate(
+                definition.getFields().stream()
+                        .map(FieldDefinition::getFieldName)
+                        .collect(Collectors.toSet()),
+                options);
+
+        definition
+                .getFields()
+                .forEach(fieldName -> FieldNameValidator.validate(fieldName.getFieldName(), options.strict()));
     }
 }

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/ServiceDefinitionValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/ServiceDefinitionValidator.java
@@ -19,6 +19,7 @@ package com.palantir.conjure.defs.validator;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
+import com.palantir.conjure.defs.ConjureOptions;
 import com.palantir.conjure.spec.ServiceDefinition;
 import java.util.Collection;
 import java.util.regex.Pattern;
@@ -30,9 +31,9 @@ public enum ServiceDefinitionValidator implements ConjureValidator<ServiceDefini
 
     private final ConjureValidator<ServiceDefinition> validator;
 
-    public static void validateAll(ServiceDefinition definition) {
+    public static void validateAll(ServiceDefinition definition, ConjureOptions options) {
         for (ServiceDefinitionValidator validator : ServiceDefinitionValidator.values()) {
-            validator.validate(definition);
+            validator.validate(definition, options);
         }
     }
 
@@ -41,8 +42,8 @@ public enum ServiceDefinitionValidator implements ConjureValidator<ServiceDefini
     }
 
     @Override
-    public void validate(ServiceDefinition definition) {
-        validator.validate(definition);
+    public void validate(ServiceDefinition definition, ConjureOptions options) {
+        validator.validate(definition, options);
     }
 
     // The ? is for reluctant matching, i.e. matching as few characters as possible.
@@ -51,7 +52,7 @@ public enum ServiceDefinitionValidator implements ConjureValidator<ServiceDefini
     @com.google.errorprone.annotations.Immutable
     private static final class UniquePathMethodsValidator implements ConjureValidator<ServiceDefinition> {
         @Override
-        public void validate(ServiceDefinition definition) {
+        public void validate(ServiceDefinition definition, ConjureOptions _options) {
             Multimap<String, String> pathToEndpoints = ArrayListMultimap.create();
             definition.getEndpoints().forEach(entry -> {
                 String methodPath =
@@ -82,7 +83,7 @@ public enum ServiceDefinitionValidator implements ConjureValidator<ServiceDefini
         private static final String RETROFIT_SUFFIX = "Retrofit";
 
         @Override
-        public void validate(ServiceDefinition definition) {
+        public void validate(ServiceDefinition definition, ConjureOptions _options) {
             Preconditions.checkState(
                     !definition.getServiceName().getName().endsWith(RETROFIT_SUFFIX),
                     "Service name must not end in %s: %s",

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/UnionDefinitionValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/UnionDefinitionValidator.java
@@ -18,6 +18,7 @@ package com.palantir.conjure.defs.validator;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.palantir.conjure.defs.ConjureOptions;
 import com.palantir.conjure.spec.UnionDefinition;
 
 @com.google.errorprone.annotations.Immutable
@@ -26,9 +27,9 @@ public enum UnionDefinitionValidator implements ConjureValidator<UnionDefinition
     NO_TRAILING_UNDERSCORE(new NoTrailingUnderscoreValidator()),
     NO_CLOBBER_TYPE(new NoClobberTypeValidator());
 
-    public static void validateAll(UnionDefinition definition) {
+    public static void validateAll(UnionDefinition definition, ConjureOptions options) {
         for (UnionDefinitionValidator validator : values()) {
-            validator.validate(definition);
+            validator.validate(definition, options);
         }
     }
 
@@ -39,15 +40,15 @@ public enum UnionDefinitionValidator implements ConjureValidator<UnionDefinition
     }
 
     @Override
-    public void validate(UnionDefinition definition) {
-        validator.validate(definition);
+    public void validate(UnionDefinition definition, ConjureOptions options) {
+        validator.validate(definition, options);
     }
 
     @com.google.errorprone.annotations.Immutable
     private static final class NoTrailingUnderscoreValidator implements ConjureValidator<UnionDefinition> {
 
         @Override
-        public void validate(UnionDefinition definition) {
+        public void validate(UnionDefinition definition, ConjureOptions _options) {
             definition.getUnion().forEach(fieldDef -> {
                 Preconditions.checkArgument(
                         !fieldDef.getFieldName().get().endsWith("_"),
@@ -73,7 +74,7 @@ public enum UnionDefinitionValidator implements ConjureValidator<UnionDefinition
         }
 
         @Override
-        public void validate(UnionDefinition definition) {
+        public void validate(UnionDefinition definition, ConjureOptions _options) {
             definition.getUnion().forEach(fieldDef -> {
                 com.palantir.logsafe.Preconditions.checkArgument(
                         !Strings.isNullOrEmpty(fieldDef.getFieldName().get()), "Union member key must not be empty");
@@ -89,7 +90,7 @@ public enum UnionDefinitionValidator implements ConjureValidator<UnionDefinition
     private static final class NoClobberTypeValidator implements ConjureValidator<UnionDefinition> {
 
         @Override
-        public void validate(UnionDefinition definition) {
+        public void validate(UnionDefinition definition, ConjureOptions _options) {
             definition.getUnion().forEach(fieldDef -> {
                 com.palantir.logsafe.Preconditions.checkArgument(
                         !fieldDef.getFieldName().get().equals("type"), "Union member key must not be 'type'");

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/UniqueFieldNamesValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/UniqueFieldNamesValidator.java
@@ -18,6 +18,7 @@ package com.palantir.conjure.defs.validator;
 
 import com.google.common.base.Preconditions;
 import com.palantir.conjure.CaseConverter;
+import com.palantir.conjure.defs.ConjureOptions;
 import com.palantir.conjure.spec.FieldName;
 import java.util.HashMap;
 import java.util.Map;
@@ -37,7 +38,7 @@ public final class UniqueFieldNamesValidator implements ConjureValidator<Set<Fie
     }
 
     @Override
-    public void validate(Set<FieldName> args) {
+    public void validate(Set<FieldName> args, ConjureOptions _options) {
         Map<FieldName, FieldName> seenNormalizedToOriginal = new HashMap<>();
         for (FieldName argName : args) {
             FieldName normalizedName = FieldNameValidator.toCase(argName, CaseConverter.Case.LOWER_CAMEL_CASE);

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ArgumentNameValidatorTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ArgumentNameValidatorTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.palantir.conjure.CaseConverter;
+import com.palantir.conjure.defs.ConjureOptions;
 import com.palantir.conjure.spec.ArgumentDefinition;
 import com.palantir.conjure.spec.ArgumentName;
 import com.palantir.conjure.spec.BodyParameterType;
@@ -37,6 +38,8 @@ import org.junit.jupiter.api.Test;
 public final class ArgumentNameValidatorTest {
 
     private final DealiasingTypeVisitor dealiasingVisitor = new DealiasingTypeVisitor(ImmutableMap.of());
+    private static final ConjureOptions OPTIONS =
+            ConjureOptions.builder().strict(false).build();
 
     @Test
     @SuppressWarnings("CheckReturnValue")
@@ -52,7 +55,8 @@ public final class ArgumentNameValidatorTest {
     public void testInvalid() {
         for (String paramName : ImmutableList.of("AB", "123", "foo_bar", "foo-bar", "foo.bar")) {
             EndpointDefinition.Builder endpoint = createEndpoint(paramName);
-            assertThatThrownBy(() -> EndpointDefinitionValidator.validateAll(endpoint.build(), dealiasingVisitor))
+            assertThatThrownBy(
+                            () -> EndpointDefinitionValidator.validateAll(endpoint.build(), dealiasingVisitor, OPTIONS))
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessage(
                             "Parameter names in endpoint paths and service definitions "

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ConjureSourceFileValidatorTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ConjureSourceFileValidatorTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableList;
+import com.palantir.conjure.defs.ConjureOptions;
 import com.palantir.conjure.spec.AliasDefinition;
 import com.palantir.conjure.spec.ConjureDefinition;
 import com.palantir.conjure.spec.Documentation;
@@ -47,6 +48,8 @@ public class ConjureSourceFileValidatorTest {
     private static final TypeName FOO = TypeName.of("Foo", PACKAGE);
     private static final TypeName BAR = TypeName.of("Bar", PACKAGE);
     private static final Documentation DOCS = Documentation.of("docs");
+    private static final ConjureOptions OPTIONS =
+            ConjureOptions.builder().strict(false).build();
 
     @Test
     public void testNoSelfRecursiveType() {
@@ -62,7 +65,7 @@ public class ConjureSourceFileValidatorTest {
                         .build())))
                 .build();
 
-        assertThatThrownBy(() -> ConjureDefinitionValidator.NO_RECURSIVE_TYPES.validate(conjureDef))
+        assertThatThrownBy(() -> ConjureDefinitionValidator.NO_RECURSIVE_TYPES.validate(conjureDef, OPTIONS))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("Illegal recursive data type: Foo -> Foo");
     }
@@ -99,7 +102,7 @@ public class ConjureSourceFileValidatorTest {
                 .types(ImmutableList.of(objectDefinition))
                 .build();
 
-        ConjureDefinitionValidator.NO_RECURSIVE_TYPES.validate(conjureDef);
+        ConjureDefinitionValidator.NO_RECURSIVE_TYPES.validate(conjureDef, OPTIONS);
     }
 
     @Test
@@ -117,7 +120,7 @@ public class ConjureSourceFileValidatorTest {
                                 .build())))
                 .build();
 
-        assertThatThrownBy(() -> ConjureDefinitionValidator.NO_RECURSIVE_TYPES.validate(conjureDef))
+        assertThatThrownBy(() -> ConjureDefinitionValidator.NO_RECURSIVE_TYPES.validate(conjureDef, OPTIONS))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageStartingWith("Illegal recursive data type: ");
     }
@@ -139,7 +142,7 @@ public class ConjureSourceFileValidatorTest {
                         .build())
                 .build();
 
-        assertThatThrownBy(() -> ConjureDefinitionValidator.ILLEGAL_MAP_KEYS.validate(conjureDef))
+        assertThatThrownBy(() -> ConjureDefinitionValidator.ILLEGAL_MAP_KEYS.validate(conjureDef, OPTIONS))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageStartingWith("Illegal map key found in return type of endpoint badEndpoint");
     }
@@ -159,7 +162,7 @@ public class ConjureSourceFileValidatorTest {
                                 .build())
                         .build()))
                 .build();
-        assertThatThrownBy(() -> ConjureDefinitionValidator.ILLEGAL_MAP_KEYS.validate(conjureDef))
+        assertThatThrownBy(() -> ConjureDefinitionValidator.ILLEGAL_MAP_KEYS.validate(conjureDef, OPTIONS))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageStartingWith("Illegal map key found in object Foo");
     }
@@ -183,7 +186,7 @@ public class ConjureSourceFileValidatorTest {
                                 .build())
                         .build()))
                 .build();
-        assertThatThrownBy(() -> ConjureDefinitionValidator.ILLEGAL_MAP_KEYS.validate(conjureDef))
+        assertThatThrownBy(() -> ConjureDefinitionValidator.ILLEGAL_MAP_KEYS.validate(conjureDef, OPTIONS))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageStartingWith("Illegal map key found in object Foo");
     }
@@ -206,7 +209,7 @@ public class ConjureSourceFileValidatorTest {
                                 .build())
                         .build()))
                 .build();
-        assertThatCode(() -> ConjureDefinitionValidator.ILLEGAL_MAP_KEYS.validate(conjureDef))
+        assertThatCode(() -> ConjureDefinitionValidator.ILLEGAL_MAP_KEYS.validate(conjureDef, OPTIONS))
                 .describedAs("External imports may be used as map keys provided the fallback type is valid")
                 .doesNotThrowAnyException();
     }
@@ -229,7 +232,7 @@ public class ConjureSourceFileValidatorTest {
                                 .build())
                         .build()))
                 .build();
-        assertThatThrownBy(() -> ConjureDefinitionValidator.ILLEGAL_MAP_KEYS.validate(conjureDef))
+        assertThatThrownBy(() -> ConjureDefinitionValidator.ILLEGAL_MAP_KEYS.validate(conjureDef, OPTIONS))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageStartingWith("Illegal map key found in object Foo");
     }

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/validator/EndpointDefinitionTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/validator/EndpointDefinitionTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.palantir.conjure.defs.ConjureOptions;
 import com.palantir.conjure.spec.AliasDefinition;
 import com.palantir.conjure.spec.ArgumentDefinition;
 import com.palantir.conjure.spec.ArgumentName;
@@ -47,6 +48,8 @@ import org.junit.jupiter.api.Test;
 
 public final class EndpointDefinitionTest {
 
+    private static final ConjureOptions OPTIONS =
+            ConjureOptions.builder().strict(false).build();
     private final DealiasingTypeVisitor emptyDealiasingVisitor = new DealiasingTypeVisitor(ImmutableMap.of());
 
     private static final EndpointName ENDPOINT_NAME = EndpointName.of("test");
@@ -69,7 +72,8 @@ public final class EndpointDefinitionTest {
                 .httpMethod(HttpMethod.GET)
                 .httpPath(HttpPath.of("/a/path"));
 
-        assertThatThrownBy(() -> EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor))
+        assertThatThrownBy(() ->
+                        EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor, OPTIONS))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Non body parameters cannot contain the 'binary' type. Parameter 'testArg' "
                         + "from endpoint 'test{http: GET /a/path}' violates this constraint.");
@@ -89,7 +93,7 @@ public final class EndpointDefinitionTest {
                 .httpPath(HttpPath.of("/a/path"));
 
         // Should not throw exception
-        EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor);
+        EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor, OPTIONS);
     }
 
     @Test
@@ -101,7 +105,8 @@ public final class EndpointDefinitionTest {
                 .httpMethod(HttpMethod.GET)
                 .httpPath(HttpPath.of("/a/path"));
 
-        assertThatThrownBy(() -> EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor))
+        assertThatThrownBy(() ->
+                        EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor, OPTIONS))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("Endpoint 'test{http: GET /a/path}' cannot have multiple body parameters: "
                         + "[bodyArg1, bodyArg2]");
@@ -119,7 +124,7 @@ public final class EndpointDefinitionTest {
                 .httpPath(HttpPath.of("/a/path"))
                 .build();
 
-        assertThatThrownBy(() -> EndpointDefinitionValidator.validateAll(definition, emptyDealiasingVisitor))
+        assertThatThrownBy(() -> EndpointDefinitionValidator.validateAll(definition, emptyDealiasingVisitor, OPTIONS))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("Endpoint BODY argument must not be optional<binary> or alias thereof: "
                         + "test{http: POST /a/path}");
@@ -145,7 +150,7 @@ public final class EndpointDefinitionTest {
                         Type.optional(OptionalType.of(Type.primitive(PrimitiveType.BINARY))),
                         Documentation.of("")))));
 
-        assertThatThrownBy(() -> EndpointDefinitionValidator.validateAll(definition, dealiasingVisitor))
+        assertThatThrownBy(() -> EndpointDefinitionValidator.validateAll(definition, dealiasingVisitor, OPTIONS))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("Endpoint BODY argument must not be optional<binary> or alias thereof: "
                         + "test{http: POST /a/path}");
@@ -170,7 +175,8 @@ public final class EndpointDefinitionTest {
                 .httpMethod(HttpMethod.GET)
                 .httpPath(HttpPath.of("/a/path"));
 
-        assertThatThrownBy(() -> EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor))
+        assertThatThrownBy(() ->
+                        EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor, OPTIONS))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("Path parameter with identifier \"paramName\" is "
                         + "defined multiple times for endpoint test{http: GET /a/path}");
@@ -188,7 +194,8 @@ public final class EndpointDefinitionTest {
                 .httpMethod(HttpMethod.GET)
                 .httpPath(HttpPath.of("/path"));
 
-        assertThatThrownBy(() -> EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor))
+        assertThatThrownBy(() ->
+                        EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor, OPTIONS))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Non body parameters cannot contain the 'binary' type. Parameter 'paramName' "
                         + "from endpoint 'test{http: GET /path}' violates this constraint.");
@@ -206,7 +213,8 @@ public final class EndpointDefinitionTest {
                 .httpMethod(HttpMethod.GET)
                 .httpPath(HttpPath.of("/path"));
 
-        assertThatThrownBy(() -> EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor))
+        assertThatThrownBy(() ->
+                        EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor, OPTIONS))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Path or query parameters of type 'bearertoken' are not allowed");
     }
@@ -223,7 +231,8 @@ public final class EndpointDefinitionTest {
                 .httpMethod(HttpMethod.GET)
                 .httpPath(HttpPath.of("/path"));
 
-        assertThatThrownBy(() -> EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor))
+        assertThatThrownBy(() ->
+                        EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor, OPTIONS))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Non body parameters cannot contain the 'binary' type. Parameter 'paramName' "
                         + "from endpoint 'test{http: GET /path}' violates this constraint.");
@@ -241,7 +250,8 @@ public final class EndpointDefinitionTest {
                 .httpMethod(HttpMethod.GET)
                 .httpPath(HttpPath.of("/path"));
 
-        assertThatThrownBy(() -> EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor))
+        assertThatThrownBy(() ->
+                        EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor, OPTIONS))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Non body parameters cannot contain the 'binary' type. Parameter 'paramName' "
                         + "from endpoint 'test{http: GET /path}' violates this constraint.");
@@ -261,7 +271,8 @@ public final class EndpointDefinitionTest {
                 .httpMethod(HttpMethod.GET)
                 .httpPath(HttpPath.of("/a/path"));
 
-        assertThatThrownBy(() -> EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor))
+        assertThatThrownBy(() ->
+                        EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor, OPTIONS))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining(
                         "Path parameters defined in endpoint but not present in path template: [paramName]");
@@ -274,7 +285,8 @@ public final class EndpointDefinitionTest {
                 .httpMethod(HttpMethod.GET)
                 .httpPath(HttpPath.of("/a/path/{paramName}"));
 
-        assertThatThrownBy(() -> EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor))
+        assertThatThrownBy(() ->
+                        EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor, OPTIONS))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("Path parameters [paramName] defined path template but not present in endpoint: "
                         + "test{http: GET /a/path/{paramName}}");
@@ -288,7 +300,8 @@ public final class EndpointDefinitionTest {
                 .httpMethod(HttpMethod.GET)
                 .httpPath(HttpPath.of("/a/path"));
 
-        assertThatThrownBy(() -> EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor))
+        assertThatThrownBy(() ->
+                        EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor, OPTIONS))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("Endpoint 'test{http: GET /a/path}' cannot be a GET and contain a body");
     }
@@ -307,7 +320,8 @@ public final class EndpointDefinitionTest {
                 .httpMethod(HttpMethod.GET)
                 .httpPath(HttpPath.of("/a/path"));
 
-        assertThatThrownBy(() -> EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor))
+        assertThatThrownBy(() ->
+                        EndpointDefinitionValidator.validateAll(definition.build(), emptyDealiasingVisitor, OPTIONS))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("Header parameters must be enums, primitives, aliases or optional primitive: "
                         + "\"someName\" is not allowed on endpoint test{http: GET /a/path}");
@@ -330,7 +344,8 @@ public final class EndpointDefinitionTest {
                 typeName,
                 TypeDefinition.object(ObjectDefinition.of(typeName, ImmutableList.of(), Documentation.of("")))));
 
-        assertThatThrownBy(() -> EndpointDefinitionValidator.validateAll(definition.build(), dealiasingVisitor))
+        assertThatThrownBy(
+                        () -> EndpointDefinitionValidator.validateAll(definition.build(), dealiasingVisitor, OPTIONS))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("Header parameters must be enums, primitives, aliases or optional primitive: "
                         + "\"someName\" is not allowed on endpoint test{http: GET /a/path}");

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/validator/EnumDefinitionValidatorTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/validator/EnumDefinitionValidatorTest.java
@@ -18,6 +18,7 @@ package com.palantir.conjure.defs.validator;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.palantir.conjure.defs.ConjureOptions;
 import com.palantir.conjure.spec.EnumDefinition;
 import com.palantir.conjure.spec.EnumValueDefinition;
 import com.palantir.conjure.spec.TypeName;
@@ -32,7 +33,9 @@ public final class EnumDefinitionValidatorTest {
                 .values(EnumValueDefinition.builder().value("FOO").build())
                 .values(EnumValueDefinition.builder().value("FOO").build());
 
-        assertThatThrownBy(() -> EnumDefinitionValidator.validateAll(definition.build()))
+        assertThatThrownBy(() -> EnumDefinitionValidator.validateAll(
+                        definition.build(),
+                        ConjureOptions.builder().strict(false).build()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Cannot declare a EnumTypeDefinition with duplicate enum values: FOO");
     }

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/validator/EnumValueDefinitionValidatorTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/validator/EnumValueDefinitionValidatorTest.java
@@ -18,16 +18,20 @@ package com.palantir.conjure.defs.validator;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.palantir.conjure.defs.ConjureOptions;
 import com.palantir.conjure.spec.EnumValueDefinition;
 import org.junit.jupiter.api.Test;
 
 public final class EnumValueDefinitionValidatorTest {
 
+    private static final ConjureOptions OPTIONS =
+            ConjureOptions.builder().strict(false).build();
+
     @Test
     public void testUnknownValueNotUsed() {
         for (String value : new String[] {"UNKNOWN", "Unknown"}) {
             assertThatThrownBy(() -> EnumValueDefinitionValidator.validateAll(
-                            EnumValueDefinition.builder().value(value).build()))
+                            EnumValueDefinition.builder().value(value).build(), OPTIONS))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("UNKNOWN is a reserved enumeration value and cannot be used in an EnumValueDefinition");
         }
@@ -37,18 +41,18 @@ public final class EnumValueDefinitionValidatorTest {
     @SuppressWarnings("CheckReturnValue")
     public void testFormat() {
         EnumValueDefinitionValidator.validateAll(
-                EnumValueDefinition.builder().value("FOO").build());
+                EnumValueDefinition.builder().value("FOO").build(), OPTIONS);
         EnumValueDefinitionValidator.validateAll(
-                EnumValueDefinition.builder().value("FOO_BAR").build());
+                EnumValueDefinition.builder().value("FOO_BAR").build(), OPTIONS);
         EnumValueDefinitionValidator.validateAll(
-                EnumValueDefinition.builder().value("FOO_123_BAR").build());
+                EnumValueDefinition.builder().value("FOO_123_BAR").build(), OPTIONS);
         EnumValueDefinitionValidator.validateAll(
-                EnumValueDefinition.builder().value("F12").build());
+                EnumValueDefinition.builder().value("F12").build(), OPTIONS);
 
         for (String value :
                 new String[] {"foo", "fooBar", "FOO-BAR", " - a", " - a_b", " - A__B", " - _A", " - A_", "123_FOO"}) {
             assertThatThrownBy(() -> EnumValueDefinitionValidator.validateAll(
-                            EnumValueDefinition.builder().value(value).build()))
+                            EnumValueDefinition.builder().value(value).build(), OPTIONS))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("Enumeration values must match format [A-Z][A-Z0-9]*(_[A-Z0-9]+)*: %s", value);
         }

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ErrorDefinitionValidatorTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ErrorDefinitionValidatorTest.java
@@ -18,6 +18,7 @@ package com.palantir.conjure.defs.validator;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.palantir.conjure.defs.ConjureOptions;
 import com.palantir.conjure.spec.ErrorCode;
 import com.palantir.conjure.spec.ErrorDefinition;
 import com.palantir.conjure.spec.ErrorNamespace;
@@ -29,6 +30,9 @@ import com.palantir.conjure.spec.TypeName;
 import org.junit.jupiter.api.Test;
 
 public class ErrorDefinitionValidatorTest {
+
+    private static final ConjureOptions OPTIONS =
+            ConjureOptions.builder().strict(false).build();
 
     @Test
     public void testUniqueArgNamesValidator() {
@@ -48,7 +52,7 @@ public class ErrorDefinitionValidatorTest {
                 .unsafeArgs(unsafeArg1)
                 .build();
 
-        assertThatThrownBy(() -> ErrorDefinitionValidator.validate(definition1))
+        assertThatThrownBy(() -> ErrorDefinitionValidator.validate(definition1, OPTIONS))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("ErrorDefinition must not contain duplicate field names (modulo case normalization): "
                         + "foo-bar vs fooBar");
@@ -69,7 +73,7 @@ public class ErrorDefinitionValidatorTest {
                 .unsafeArgs(unsafeArg2)
                 .build();
 
-        assertThatThrownBy(() -> ErrorDefinitionValidator.validate(definition2))
+        assertThatThrownBy(() -> ErrorDefinitionValidator.validate(definition2, OPTIONS))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("ErrorDefinition must not contain duplicate field names (modulo case normalization): "
                         + "foo-bar vs foo_bar");

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/validator/FieldNameValidatorTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/validator/FieldNameValidatorTest.java
@@ -26,17 +26,36 @@ public final class FieldNameValidatorTest {
 
     @Test
     public void testValidNames() {
-        FieldNameValidator.validate(FieldName.of("camel"));
-        FieldNameValidator.validate(FieldName.of("camelCase"));
-        FieldNameValidator.validate(FieldName.of("camelCase1"));
-        FieldNameValidator.validate(FieldName.of("camel1Case2"));
-        FieldNameValidator.validate(FieldName.of("kebab-case"));
-        FieldNameValidator.validate(FieldName.of("kebab1-case123"));
-        FieldNameValidator.validate(FieldName.of("snake_case"));
-        FieldNameValidator.validate(FieldName.of("snake1_case123"));
-        FieldNameValidator.validate(FieldName.of("xCoordinate"));
-        FieldNameValidator.validate(FieldName.of("defaultXPosition"));
-        FieldNameValidator.validate(FieldName.of("defaultX"));
+        FieldNameValidator.validate(FieldName.of("camel"), false);
+        FieldNameValidator.validate(FieldName.of("camelCase"), false);
+        FieldNameValidator.validate(FieldName.of("camelCase1"), false);
+        FieldNameValidator.validate(FieldName.of("camel1Case2"), false);
+        FieldNameValidator.validate(FieldName.of("kebab-case"), false);
+        FieldNameValidator.validate(FieldName.of("kebab1-case123"), false);
+        FieldNameValidator.validate(FieldName.of("snake_case"), false);
+        FieldNameValidator.validate(FieldName.of("snake1_case123"), false);
+        FieldNameValidator.validate(FieldName.of("xCoordinate"), false);
+        FieldNameValidator.validate(FieldName.of("defaultXPosition"), false);
+        FieldNameValidator.validate(FieldName.of("defaultX"), false);
+    }
+
+    @Test
+    public void testValidNames_strict() {
+        FieldNameValidator.validate(FieldName.of("camel"), true);
+        FieldNameValidator.validate(FieldName.of("camelCase"), true);
+        FieldNameValidator.validate(FieldName.of("camelCase1"), true);
+        FieldNameValidator.validate(FieldName.of("camel1Case2"), true);
+        assertThatThrownBy(() -> FieldNameValidator.validate(FieldName.of("kebab-case"), true))
+                .hasMessageContaining("lowerCamelCase");
+        assertThatThrownBy(() -> FieldNameValidator.validate(FieldName.of("kebab1-case123"), true))
+                .hasMessageContaining("lowerCamelCase");
+        assertThatThrownBy(() -> FieldNameValidator.validate(FieldName.of("snake_case"), true))
+                .hasMessageContaining("lowerCamelCase");
+        assertThatThrownBy(() -> FieldNameValidator.validate(FieldName.of("snake1_case123"), true))
+                .hasMessageContaining("lowerCamelCase");
+        FieldNameValidator.validate(FieldName.of("xCoordinate"), true);
+        FieldNameValidator.validate(FieldName.of("defaultXPosition"), true);
+        FieldNameValidator.validate(FieldName.of("defaultX"), true);
     }
 
     @Test

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ObjectDefinitionValidatorTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ObjectDefinitionValidatorTest.java
@@ -18,6 +18,7 @@ package com.palantir.conjure.defs.validator;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.palantir.conjure.defs.ConjureOptions;
 import com.palantir.conjure.spec.FieldDefinition;
 import com.palantir.conjure.spec.FieldName;
 import com.palantir.conjure.spec.ObjectDefinition;
@@ -50,7 +51,8 @@ public final class ObjectDefinitionValidatorTest {
                 .fields(field2)
                 .build();
 
-        assertThatThrownBy(() -> ObjectDefinitionValidator.validate(definition))
+        assertThatThrownBy(() -> ObjectDefinitionValidator.validate(
+                        definition, ConjureOptions.builder().strict(false).build()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage(String.format(
                         "ObjectDefinition must not contain duplicate field names "

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ParamIdValidatorTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ParamIdValidatorTest.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.net.HttpHeaders;
 import com.palantir.conjure.CaseConverter;
+import com.palantir.conjure.defs.ConjureOptions;
 import com.palantir.conjure.spec.ArgumentDefinition;
 import com.palantir.conjure.spec.ArgumentName;
 import com.palantir.conjure.spec.EndpointDefinition;
@@ -42,6 +43,8 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public final class ParamIdValidatorTest {
+    private static final ConjureOptions OPTIONS =
+            ConjureOptions.builder().strict(false).build();
     private static final ArgumentName PARAMETER_NAME = ArgumentName.of("arg");
     private final DealiasingTypeVisitor dealiasingVisitor = new DealiasingTypeVisitor(ImmutableMap.of());
 
@@ -127,7 +130,7 @@ public final class ParamIdValidatorTest {
                     .endpointName(EndpointName.of("test"))
                     .build();
 
-            EndpointDefinitionValidator.validateAll(definition, dealiasingVisitor);
+            EndpointDefinitionValidator.validateAll(definition, dealiasingVisitor, OPTIONS);
         }));
     }
 }

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/validator/UnionDefinitionValidatorTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/validator/UnionDefinitionValidatorTest.java
@@ -19,6 +19,7 @@ package com.palantir.conjure.defs.validator;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableList;
+import com.palantir.conjure.defs.ConjureOptions;
 import com.palantir.conjure.spec.FieldDefinition;
 import com.palantir.conjure.spec.FieldName;
 import com.palantir.conjure.spec.PrimitiveType;
@@ -29,6 +30,9 @@ import org.junit.jupiter.api.Test;
 
 public final class UnionDefinitionValidatorTest {
 
+    private static final ConjureOptions OPTIONS =
+            ConjureOptions.builder().strict(false).build();
+
     @Test
     public void testUnionMemberKeyMustNotBeEmpty() {
         FieldDefinition fieldDefinition = FieldDefinition.builder()
@@ -36,10 +40,12 @@ public final class UnionDefinitionValidatorTest {
                 .type(Type.primitive(PrimitiveType.STRING))
                 .build();
 
-        assertThatThrownBy(() -> UnionDefinitionValidator.validateAll(UnionDefinition.builder()
-                        .union(fieldDefinition)
-                        .typeName(TypeName.of("string", ""))
-                        .build()))
+        assertThatThrownBy(() -> UnionDefinitionValidator.validateAll(
+                        UnionDefinition.builder()
+                                .union(fieldDefinition)
+                                .typeName(TypeName.of("string", ""))
+                                .build(),
+                        OPTIONS))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageStartingWith("Union member key must not be empty");
     }
@@ -52,10 +58,12 @@ public final class UnionDefinitionValidatorTest {
                     .type(Type.primitive(PrimitiveType.STRING))
                     .build();
 
-            assertThatThrownBy(() -> UnionDefinitionValidator.validateAll(UnionDefinition.builder()
-                            .union(fieldDefinition)
-                            .typeName(TypeName.of("string", ""))
-                            .build()))
+            assertThatThrownBy(() -> UnionDefinitionValidator.validateAll(
+                            UnionDefinition.builder()
+                                    .union(fieldDefinition)
+                                    .typeName(TypeName.of("string", ""))
+                                    .build(),
+                            OPTIONS))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessageStartingWith(String.format("Union member key must be a valid Java identifier: %s", key));
         });
@@ -67,10 +75,12 @@ public final class UnionDefinitionValidatorTest {
                 .fieldName(FieldName.of("foo_"))
                 .type(Type.primitive(PrimitiveType.STRING))
                 .build();
-        assertThatThrownBy(() -> UnionDefinitionValidator.validateAll(UnionDefinition.builder()
-                        .union(fieldDefinition)
-                        .typeName(TypeName.of("string", ""))
-                        .build()))
+        assertThatThrownBy(() -> UnionDefinitionValidator.validateAll(
+                        UnionDefinition.builder()
+                                .union(fieldDefinition)
+                                .typeName(TypeName.of("string", ""))
+                                .build(),
+                        OPTIONS))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageStartingWith("Union member key must not end with an underscore: foo_");
     }

--- a/conjure/src/main/java/com/palantir/conjure/cli/CliConfiguration.java
+++ b/conjure/src/main/java/com/palantir/conjure/cli/CliConfiguration.java
@@ -35,11 +35,17 @@ public abstract class CliConfiguration {
 
     abstract Map<String, Object> extensions();
 
+    @SuppressWarnings("checkstyle:DesignForExtension")
+    @Value.Default
+    public boolean strict() {
+        return false;
+    }
+
     static Builder builder() {
         return new Builder();
     }
 
-    static CliConfiguration create(String input, String outputIrFile, Map<String, Object> extensions) {
+    static CliConfiguration create(String input, String outputIrFile, Map<String, Object> extensions, boolean strict) {
         File inputFile = new File(input);
 
         Collection<File> inputFiles;
@@ -58,6 +64,7 @@ public abstract class CliConfiguration {
                 .inputFiles(inputFiles)
                 .outputIrFile(outputFile)
                 .extensions(extensions)
+                .strict(strict)
                 .build();
     }
 

--- a/conjure/src/main/java/com/palantir/conjure/cli/ConjureCli.java
+++ b/conjure/src/main/java/com/palantir/conjure/cli/ConjureCli.java
@@ -141,6 +141,12 @@ public final class ConjureCli implements Runnable {
         @CommandLine.Option(names = "--verbose", description = "")
         private boolean verbose;
 
+        @CommandLine.Option(
+                names = "--strict",
+                description = "Strict mode fails validation rather than logging warnings "
+                        + "when non-camel-case field names and query parameters are used")
+        private boolean strict;
+
         @CommandLine.Option(names = "--extensions", description = "")
         @Nullable
         private String extensions;
@@ -179,7 +185,8 @@ public final class ConjureCli implements Runnable {
                     output,
                     Optional.ofNullable(extensions)
                             .map(ConjureCli::parseExtensions)
-                            .orElseGet(Collections::emptyMap));
+                            .orElseGet(Collections::emptyMap),
+                    strict);
         }
 
         @Override


### PR DESCRIPTION
## Before this PR
warnings, but no way to fail when they're introduced

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
fix #974: The Conjure parser supports a `--strict` flag to fail on non-camel-case fields
==COMMIT_MSG==

## Possible downsides?
gradle-conjure doesn't support additional arbitrary args like the other generators yet, this will require a feature there as well.

