### PR TITLE
Late-resolve imports to enable circular type references

### DIFF
--- a/conjure-core/src/main/java/com/palantir/conjure/defs/Conjure.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/Conjure.java
@@ -22,7 +22,7 @@ import com.palantir.conjure.parser.NormalizeDefinition;
 import com.palantir.conjure.spec.ConjureDefinition;
 import java.io.File;
 import java.util.Collection;
-import java.util.List;
+import java.util.Map;
 
 public final class Conjure {
     public static final Integer SUPPORTED_IR_VERSION = 1;
@@ -33,7 +33,7 @@ public final class Conjure {
      * Deserializes {@link ConjureDefinition} from their YAML representations in the given files.
      */
     public static ConjureDefinition parse(Collection<File> files) {
-        List<AnnotatedConjureSourceFile> sourceFiles = ConjureParser.parseAnnotated(files);
+        Map<String, AnnotatedConjureSourceFile> sourceFiles = ConjureParser.parseAnnotated(files);
         ConjureDefinition ir = ConjureParserUtils.parseConjureDef(sourceFiles);
         return NormalizeDefinition.normalize(ir);
     }

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureTypeParserVisitor.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureTypeParserVisitor.java
@@ -18,6 +18,7 @@ package com.palantir.conjure.defs;
 
 import com.google.common.base.Preconditions;
 import com.palantir.conjure.exceptions.ConjureIllegalStateException;
+import com.palantir.conjure.parser.AnnotatedConjureSourceFile;
 import com.palantir.conjure.parser.types.BaseObjectTypeDefinition;
 import com.palantir.conjure.parser.types.ConjureTypeVisitor;
 import com.palantir.conjure.parser.types.TypesDefinition;
@@ -28,14 +29,15 @@ import com.palantir.conjure.parser.types.collect.ListType;
 import com.palantir.conjure.parser.types.collect.MapType;
 import com.palantir.conjure.parser.types.collect.OptionalType;
 import com.palantir.conjure.parser.types.collect.SetType;
+import com.palantir.conjure.parser.types.names.Namespace;
 import com.palantir.conjure.parser.types.primitive.PrimitiveType;
-import com.palantir.conjure.parser.types.reference.ConjureImports;
 import com.palantir.conjure.parser.types.reference.ExternalTypeDefinition;
 import com.palantir.conjure.parser.types.reference.ForeignReferenceType;
 import com.palantir.conjure.parser.types.reference.LocalReferenceType;
 import com.palantir.conjure.spec.ExternalReference;
 import com.palantir.conjure.spec.Type;
 import com.palantir.conjure.spec.TypeName;
+import java.util.Map;
 import java.util.Optional;
 
 /** The core translator between parsed/raw types and the IR spec representation exposed to compilers. */
@@ -51,9 +53,16 @@ public final class ConjureTypeParserVisitor implements ConjureTypeVisitor<Type> 
     public static final class ByParsedRepresentationTypeNameResolver implements ReferenceTypeResolver {
 
         private final TypesDefinition types;
+        private final Map<Namespace, String> importProviders;
+        private final Map<String, AnnotatedConjureSourceFile> externalTypes;
 
-        public ByParsedRepresentationTypeNameResolver(TypesDefinition types) {
+        public ByParsedRepresentationTypeNameResolver(
+                TypesDefinition types,
+                Map<Namespace, String> importProviders,
+                Map<String, AnnotatedConjureSourceFile> externalTypes) {
             this.types = types;
+            this.importProviders = importProviders;
+            this.externalTypes = externalTypes;
         }
 
         @Override
@@ -63,10 +72,13 @@ public final class ConjureTypeParserVisitor implements ConjureTypeVisitor<Type> 
 
         @Override
         public Type resolve(ForeignReferenceType reference) {
-            ConjureImports conjureImports = types.conjureImports().get(reference.namespace());
-            Preconditions.checkNotNull(conjureImports, "Import not found for namespace: %s", reference.namespace());
+            String namespaceFile = importProviders.get(reference.namespace());
+            Preconditions.checkNotNull(namespaceFile, "Import not found for namespace: %s", reference.namespace());
+            AnnotatedConjureSourceFile externalFile = externalTypes.get(namespaceFile);
+            Preconditions.checkNotNull(
+                    externalFile, "File not found for namespace: %s @ %s", reference.namespace(), namespaceFile);
             return resolveFromTypeName(
-                    reference.type(), conjureImports.conjure().types());
+                    reference.type(), externalFile.conjureSourceFile().types());
         }
 
         private static Type resolveFromTypeName(

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/AnnotatedConjureSourceFile.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/AnnotatedConjureSourceFile.java
@@ -17,13 +17,17 @@
 package com.palantir.conjure.parser;
 
 import com.palantir.conjure.defs.ConjureImmutablesStyle;
+import com.palantir.conjure.parser.types.names.Namespace;
 import java.io.File;
+import java.util.Map;
 import org.immutables.value.Value;
 
 @Value.Immutable
 @ConjureImmutablesStyle
 public interface AnnotatedConjureSourceFile {
     ConjureSourceFile conjureSourceFile();
+
+    Map<Namespace, String> importProviders();
 
     File sourceFile();
 

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/ConjureParser.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/ConjureParser.java
@@ -23,20 +23,20 @@ import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.exceptions.ConjureRuntimeException;
 import com.palantir.conjure.parser.types.TypesDefinition;
-import com.palantir.conjure.parser.types.names.Namespace;
-import com.palantir.conjure.parser.types.reference.ConjureImports;
+import com.palantir.logsafe.exceptions.SafeIllegalStateException;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
+import java.util.Map.Entry;
+import java.util.Queue;
 import java.util.stream.Collectors;
 
 public final class ConjureParser {
@@ -59,34 +59,66 @@ public final class ConjureParser {
 
     /** Deserializes a {@link ConjureSourceFile} from its YAML representation in the given file. */
     public static ConjureSourceFile parse(File file) {
-        RecursiveParser parser = new RecursiveParser();
+        CachingParser parser = new CachingParser();
         return parser.parse(file);
     }
 
-    public static AnnotatedConjureSourceFile parseAnnotated(File file) {
-        RecursiveParser parser = new RecursiveParser();
-        return parseAnnotated(parser, file);
+    /**
+     * Parse file & all imports (recursively).
+     */
+    public static Map<String, AnnotatedConjureSourceFile> parseAnnotated(File file) {
+        return parseAnnotated(ImmutableList.of(file));
     }
 
-    public static List<AnnotatedConjureSourceFile> parseAnnotated(Collection<File> files) {
-        RecursiveParser parser = new RecursiveParser();
-        return files.stream().map(file -> parseAnnotated(parser, file)).collect(Collectors.toList());
+    /**
+     * Parse file & all imports (recursively).
+     */
+    public static Map<String, AnnotatedConjureSourceFile> parseAnnotated(Collection<File> files) {
+        CachingParser parser = new CachingParser();
+
+        Map<String, AnnotatedConjureSourceFile> parsed = new HashMap<>();
+        Queue<File> toProcess = new ArrayDeque<>(files);
+
+        while (!toProcess.isEmpty()) {
+            File nextFile = toProcess.poll();
+            String key = nextFile.getAbsolutePath();
+
+            if (!parsed.containsKey(key)) {
+                AnnotatedConjureSourceFile annotatedConjureSourceFile = parseSingleFile(parser, nextFile);
+                parsed.put(key, annotatedConjureSourceFile);
+
+                // Add all imports as files to be parsed
+                annotatedConjureSourceFile.importProviders().values().stream()
+                        .map(File::new)
+                        .forEach(toProcess::add);
+            }
+        }
+
+        return parsed;
     }
 
-    private static AnnotatedConjureSourceFile parseAnnotated(RecursiveParser parser, File file) {
+    private static AnnotatedConjureSourceFile parseSingleFile(CachingParser parser, File file) {
+        ConjureSourceFile parsed = parser.parse(file);
+
         return AnnotatedConjureSourceFile.builder()
-                .conjureSourceFile(parser.parse(file))
+                .conjureSourceFile(parsed)
                 .sourceFile(file)
+                // Hoist imports
+                .importProviders(parsed.types().conjureImports().entrySet().stream()
+                        .collect(Collectors.toMap(Entry::getKey, entry -> entry.getValue()
+                                .absoluteFile()
+                                .orElseThrow(() -> new SafeIllegalStateException(
+                                        "Absolute file MUST be resolved as part of parsing stage"))
+                                .getAbsolutePath())))
                 .build();
     }
 
-    private static final class RecursiveParser {
+    private static final class CachingParser {
+        // From absolute path to the parsed file
         private final Map<String, ConjureSourceFile> cache;
-        private final Set<String> currentDepthFirstPath;
 
-        private RecursiveParser() {
+        private CachingParser() {
             this.cache = new HashMap<>();
-            this.currentDepthFirstPath = new LinkedHashSet<>(); // maintain order so we can print the cycle
         }
 
         ConjureSourceFile parse(File file) {
@@ -99,54 +131,36 @@ public final class ConjureParser {
                 return result;
             }
 
-            if (!currentDepthFirstPath.add(file.getAbsolutePath())) {
-                String cycle = currentDepthFirstPath.stream().reduce("", (left, right) -> left + " -> " + right)
-                        + " -> " + file.getAbsolutePath();
-                throw new CyclicImportException(cycle);
-            }
-
             result = parseInternal(file);
             cache.put(file.getAbsolutePath(), result);
             return result;
         }
 
         private ConjureSourceFile parseInternal(File file) {
-            // Note(rfink): The mechanism of parsing the ConjureSourceFile and the imports separately isn't pretty,
-            // but it's better than the previous implementation where ConjureImports types were passed around all
-            // over the place. Main obstacle to simpler parsing is that Jackson parsers don't have context, i.e., it's
-            // impossible to know the base-path w.r.t. which the imported file is declared.
             if (!Files.exists(file.toPath())) {
                 throw new ImportNotFoundException(file);
             }
 
             try {
                 ConjureSourceFile definition = MAPPER.readValue(file, ConjureSourceFile.class);
-                Map<Namespace, ConjureImports> imports = parseImports(
-                        definition.types().conjureImports(), file.toPath().getParent());
+
+                // For ease of book-keeping, resolve the import paths here
+                Path baseDir = file.toPath().getParent();
                 return ConjureSourceFile.builder()
                         .from(definition)
                         .types(TypesDefinition.builder()
                                 .from(definition.types())
-                                .conjureImports(imports)
+                                .conjureImports(definition.types().conjureImports().entrySet().stream()
+                                        .collect(Collectors.toMap(
+                                                Entry::getKey,
+                                                // Resolve absolute path to ensure we don't need to track this anymore
+                                                conjureImport ->
+                                                        conjureImport.getValue().resolve(baseDir))))
                                 .build())
                         .build();
             } catch (IOException e) {
                 throw new ConjureRuntimeException(String.format("Error while parsing %s:", file), e);
             }
-        }
-
-        /**
-         * Replaces the (typically empty) ImportedTypes object for each namespace by an object with inlined/populated
-         * {@link ConjureImports#conjure()} imported definitions}.
-         */
-        private Map<Namespace, ConjureImports> parseImports(
-                Map<Namespace, ConjureImports> declaredImports, Path baseDir) {
-            return declaredImports.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, entry -> {
-                String importedFile = entry.getValue().file();
-                ConjureSourceFile importedConjure =
-                        parse(baseDir.resolve(importedFile).toFile());
-                return ConjureImports.withResolvedImports(importedFile, importedConjure);
-            }));
         }
     }
 

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/ConjureParser.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/ConjureParser.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.exceptions.ConjureRuntimeException;
 import com.palantir.conjure.parser.types.TypesDefinition;
 import com.palantir.logsafe.exceptions.SafeIllegalStateException;
+import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -80,7 +81,12 @@ public final class ConjureParser {
         Queue<File> toProcess = new ArrayDeque<>(files);
 
         while (!toProcess.isEmpty()) {
-            File nextFile = toProcess.poll();
+            File nextFile;
+            try {
+                nextFile = toProcess.poll().getCanonicalFile();
+            } catch (IOException e) {
+                throw new SafeRuntimeException("Couldn't canonicalize file path", e);
+            }
             String key = nextFile.getAbsolutePath();
 
             if (!parsed.containsKey(key)) {

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/types/reference/ConjureImports.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/types/reference/ConjureImports.java
@@ -19,7 +19,9 @@ package com.palantir.conjure.parser.types.reference;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.palantir.conjure.defs.ConjureImmutablesStyle;
+import com.palantir.logsafe.exceptions.SafeRuntimeException;
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
 import org.immutables.value.Value;
@@ -47,9 +49,13 @@ public interface ConjureImports {
     @Value.Auxiliary
     @JsonIgnore
     default ConjureImports resolve(Path baseDir) {
-        return ImmutableConjureImports.builder()
-                .file(file())
-                .absoluteFile(baseDir.resolve(file()).toFile())
-                .build();
+        try {
+            return ImmutableConjureImports.builder()
+                    .file(file())
+                    .absoluteFile(baseDir.resolve(file()).toFile().getCanonicalFile())
+                    .build();
+        } catch (IOException e) {
+            throw new SafeRuntimeException("Couldn't canonicalize file path", e);
+        }
     }
 }

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/types/reference/ConjureImports.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/types/reference/ConjureImports.java
@@ -17,8 +17,11 @@
 package com.palantir.conjure.parser.types.reference;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.palantir.conjure.defs.ConjureImmutablesStyle;
-import com.palantir.conjure.parser.ConjureSourceFile;
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Optional;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -31,21 +34,22 @@ public interface ConjureImports {
      */
     String file();
 
-    ConjureSourceFile conjure();
+    /**
+     * The resolved file from which types are to be imported.
+     */
+    Optional<File> absoluteFile();
 
     @JsonCreator
-    static ConjureImports fromFile(String file) {
-        return ImmutableConjureImports.builder()
-                .file(file)
-                // When deserializing this object from user-supplied conjure yaml, we just fill in the file.
-                .conjure(ConjureSourceFile.builder().build())
-                .build();
+    static ConjureImports relativeFile(String file) {
+        return ImmutableConjureImports.builder().file(file).build();
     }
 
-    static ConjureImports withResolvedImports(String file, ConjureSourceFile conjureDefinition) {
+    @Value.Auxiliary
+    @JsonIgnore
+    default ConjureImports resolve(Path baseDir) {
         return ImmutableConjureImports.builder()
-                .file(file)
-                .conjure(conjureDefinition)
+                .file(file())
+                .absoluteFile(baseDir.resolve(file()).toFile())
                 .build();
     }
 }

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/ConjureDefTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/ConjureDefTest.java
@@ -29,16 +29,39 @@ public class ConjureDefTest {
 
     @Test
     public void resolvesImportedAliases() {
-        ConjureDefinition conjureDefinition = ConjureParserUtils.parseConjureDef(ImmutableList.of(
-                ConjureParser.parseAnnotated(new File("src/test/resources/example-conjure-imports.yml"))));
+        ConjureDefinition conjureDefinition = ConjureParserUtils.parseConjureDef(
+                ConjureParser.parseAnnotated(new File("src/test/resources/example-conjure-imports.yml")));
+        assertThat(conjureDefinition.getTypes()).hasSize(3);
+    }
+
+    @Test
+    public void resolvesRecursiveImportType() {
+        ConjureDefinition conjureDefinition = ConjureParserUtils.parseConjureDef(
+                ConjureParser.parseAnnotated(new File("src/test/resources/example-recursive-imports.yml")));
         assertThat(conjureDefinition.getTypes()).hasSize(1);
+    }
+
+    @Test
+    public void resolvesCircularType_singleFile() {
+        ConjureDefinition conjureDefinition = ConjureParserUtils.parseConjureDef(
+                ConjureParser.parseAnnotated(new File("src/test/resources/example-circular.yml")));
+        assertThat(conjureDefinition.getTypes()).hasSize(2);
+    }
+
+    @Test
+    public void resolvesCircularType_multiFile() {
+        ConjureDefinition conjureDefinition =
+                ConjureParserUtils.parseConjureDef(ConjureParser.parseAnnotated(ImmutableList.of(
+                        new File("src/test/resources/example-multi-file-circular-import-a.yml"),
+                        new File("src/test/resources/example-multi-file-circular-import-b.yml"))));
+        assertThat(conjureDefinition.getTypes()).hasSize(2);
     }
 
     // Test currently fails as it attempts to parse a TypeScript package name as a java package
     @Test
     @Ignore
     public void handlesNonJavaExternalType() {
-        ConjureParserUtils.parseConjureDef(ImmutableList.of(
-                ConjureParser.parseAnnotated(new File("src/test/resources/example-external-types.yml"))));
+        ConjureParserUtils.parseConjureDef(
+                ConjureParser.parseAnnotated(new File("src/test/resources/example-external-types.yml")));
     }
 }

--- a/conjure-core/src/test/java/com/palantir/conjure/parser/ConjureParserTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/parser/ConjureParserTest.java
@@ -51,9 +51,8 @@ public class ConjureParserTest {
     }
 
     @Test
-    public void cyclicImportsAreNotAllowed() throws IOException {
-        assertThatThrownBy(() -> ConjureParser.parse(new File("src/test/resources/example-recursive-imports.yml")))
-                .isInstanceOf(ConjureParser.CyclicImportException.class);
+    public void cyclicImportsAreAllowed() throws IOException {
+        ConjureParser.parse(new File("src/test/resources/example-recursive-imports.yml"));
     }
 
     @Test

--- a/conjure-core/src/test/java/com/palantir/conjure/parser/services/ServiceDefinitionTests.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/parser/services/ServiceDefinitionTests.java
@@ -269,7 +269,7 @@ public final class ServiceDefinitionTests {
                                         .build())
                                 .build())
                         .putServices(
-                                TypeName.of("TestService"),
+                                TypeName.of("MyTestService"),
                                 ServiceDefinition.builder()
                                         .doNotUseName("Test Service")
                                         .conjurePackage(ConjurePackage.of("test.api"))
@@ -286,6 +286,7 @@ public final class ServiceDefinitionTests {
                                                         .args(ImmutableMap.of(
                                                                 ParameterName.of("foo"),
                                                                 ArgumentDefinition.builder()
+                                                                        .paramId(ParameterName.of("Foo"))
                                                                         .paramType(ArgumentDefinition.ParamType.HEADER)
                                                                         .type(LocalReferenceType.of(
                                                                                 TypeName.of("StringAlias")))

--- a/conjure-core/src/test/resources/example-circular.yml
+++ b/conjure-core/src/test/resources/example-circular.yml
@@ -1,0 +1,10 @@
+types:
+  definitions:
+    default-package: test.api.with.circular
+    objects:
+      ObjectOne:
+        fields:
+          value: optional<ObjectTwo>
+      ObjectTwo:
+        fields:
+          value: optional<ObjectOne>

--- a/conjure-core/src/test/resources/example-multi-file-circular-import-a.yml
+++ b/conjure-core/src/test/resources/example-multi-file-circular-import-a.yml
@@ -1,0 +1,9 @@
+types:
+  conjure-imports:
+    imported: example-multi-file-circular-import-b.yml
+  definitions:
+    default-package: test.api.circular.one
+    objects:
+      ObjectOne:
+        fields:
+          value: optional<imported.ObjectTwo>

--- a/conjure-core/src/test/resources/example-multi-file-circular-import-b.yml
+++ b/conjure-core/src/test/resources/example-multi-file-circular-import-b.yml
@@ -1,0 +1,9 @@
+types:
+  conjure-imports:
+    imported: example-multi-file-circular-import-a.yml
+  definitions:
+    default-package: test.api.circular.two
+    objects:
+      ObjectTwo:
+        fields:
+          value: optional<imported.ObjectOne>

--- a/conjure-core/src/test/resources/example-recursive-imports.yml
+++ b/conjure-core/src/test/resources/example-recursive-imports.yml
@@ -4,5 +4,6 @@ types:
   definitions:
     default-package: test.api.with.imports
     objects:
-      SimpleObject:
-        alias: string
+      RecursiveObject:
+        fields:
+          foo: optional<imports.RecursiveObject>

--- a/conjure-core/src/test/resources/test-service.yml
+++ b/conjure-core/src/test/resources/test-service.yml
@@ -16,7 +16,7 @@ types:
         alias: string
 
 services:
-  TestService:
+  MyTestService:
     name: Test Service
     package: test.api
 
@@ -30,5 +30,6 @@ services:
         args:
           foo:
             type: StringAlias
+            param-id: Foo
             param-type: header
             tags: ['safe']

--- a/conjure/src/test/java/com/palantir/conjure/cli/ConjureCliTest.java
+++ b/conjure/src/test/java/com/palantir/conjure/cli/ConjureCliTest.java
@@ -129,7 +129,9 @@ public final class ConjureCliTest {
     @Test
     public void generatesCode() {
         CliConfiguration configuration = CliConfiguration.builder()
-                .inputFiles(ImmutableList.of(new File("src/test/resources/test-service.yml")))
+                .inputFiles(ImmutableList.of(
+                        new File("src/test/resources/complex/api.yml"),
+                        new File("src/test/resources/complex/api-2.yml")))
                 .outputIrFile(outputFile)
                 .build();
         ConjureCli.CompileCommand.generate(configuration);

--- a/conjure/src/test/resources/complex/api-2.yml
+++ b/conjure/src/test/resources/complex/api-2.yml
@@ -1,0 +1,18 @@
+types:
+  conjure-imports:
+    id: ./id.yml
+    objects: ./objects.yml
+
+services:
+  TestService2:
+    name: Test Service 2
+    package: test.api
+
+    endpoints:
+      get:
+        http: GET /get/{simpleId}
+        args:
+          simpleId:
+            type: id.SimpleId
+
+        returns: objects.SimpleObject

--- a/conjure/src/test/resources/complex/api.yml
+++ b/conjure/src/test/resources/complex/api.yml
@@ -1,0 +1,18 @@
+types:
+  conjure-imports:
+    id: ./id.yml
+    objects: ./objects.yml
+
+services:
+  TestService:
+    name: Test Service
+    package: test.api
+
+    endpoints:
+      get:
+        http: GET /get/{simpleId}
+        args:
+          simpleId:
+            type: id.SimpleId
+
+        returns: objects.SimpleObject

--- a/conjure/src/test/resources/complex/id.yml
+++ b/conjure/src/test/resources/complex/id.yml
@@ -1,0 +1,6 @@
+types:
+  definitions:
+    default-package: test.api
+    objects:
+      SimpleId:
+        alias: uuid

--- a/conjure/src/test/resources/complex/objects.yml
+++ b/conjure/src/test/resources/complex/objects.yml
@@ -1,0 +1,11 @@
+types:
+  conjure-imports:
+    id: ./id.yml
+
+  definitions:
+    default-package: test.api
+    objects:
+      SimpleObject:
+        fields:
+          id: id.SimpleId
+          stringField: string


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
https://github.com/palantir/conjure/pull/948 was reverted due to erroneous validation failures. This was caused by paths not being canonicalized properly, causing the same file to be loaded multiple times (e.g. `/.../conjure/id.yml` & `/.../conjure/./id.yml`). This canonicalizes the file in the import & at parsing time.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Late-resolve imports to enable circular type references
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
- Still testing on repositories to validate there wasn't more than one bug in my approach
