### PR TITLE
Fix references with container prefixes `set`/`list`/`optional`

### DIFF
--- a/changelog/@unreleased/pr-1099.v2.yml
+++ b/changelog/@unreleased/pr-1099.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix references with container prefixes `set`/`list`/`optional`
+  links:
+  - https://github.com/palantir/conjure/pull/1099

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/types/TypeParser.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/types/TypeParser.java
@@ -30,6 +30,7 @@ import com.palantir.conjure.parser.types.reference.LocalReferenceType;
 import com.palantir.parsec.ParseException;
 import com.palantir.parsec.Parser;
 import com.palantir.parsec.ParserState;
+import com.palantir.parsec.ParserState.MarkedLocation;
 import com.palantir.parsec.Parsers;
 import com.palantir.parsec.StringParserState;
 import com.palantir.parsec.parsers.ExpectationResult;
@@ -90,14 +91,13 @@ public enum TypeParser implements Parser<ConjureType> {
 
         @Override
         public LocalReferenceType parse(ParserState input) throws ParseException {
-            input.mark();
+            MarkedLocation mark = input.mark();
             String typeReference = REF_PARSER.parse(input);
             if (typeReference == null) {
-                input.rewind();
+                mark.rewind();
                 return null;
             }
             TypeName typeName = TypeName.of(typeReference);
-            input.release();
             return LocalReferenceType.of(typeName);
         }
 

--- a/conjure-core/src/main/java/com/palantir/parsec/ParseException.java
+++ b/conjure-core/src/main/java/com/palantir/parsec/ParseException.java
@@ -23,13 +23,13 @@ public final class ParseException extends Exception {
 
     public ParseException(String message, ParserState state) {
         this.message = message;
-        this.state = state;
+        this.state = state.snapshot();
     }
 
     public ParseException(String message, ParserState state, Exception cause) {
         super(cause);
         this.message = message;
-        this.state = state;
+        this.state = state.snapshot();
     }
 
     @Override

--- a/conjure-core/src/main/java/com/palantir/parsec/ParserState.java
+++ b/conjure-core/src/main/java/com/palantir/parsec/ParserState.java
@@ -44,7 +44,7 @@ public interface ParserState {
 
     String fetchSnippetForException();
 
-    /** Creates an immutable state snapshot. */
+    /** Creates a new state object identical to this one, which does not follow location mutations to the original. */
     ParserState snapshot();
 
     interface MarkedLocation {

--- a/conjure-core/src/main/java/com/palantir/parsec/ParserState.java
+++ b/conjure-core/src/main/java/com/palantir/parsec/ParserState.java
@@ -16,6 +16,8 @@
 
 package com.palantir.parsec;
 
+import com.google.errorprone.annotations.CheckReturnValue;
+
 public interface ParserState {
 
     /**
@@ -35,19 +37,20 @@ public interface ParserState {
     /**
      * Mark beginning of an interesting feature (held as a stack).
      */
-    void mark();
-
-    /**
-     * Pop the last mark.
-     */
-    void release();
-
-    /**
-     * Pop the last mark and return to its position.
-     */
-    void rewind();
+    @CheckReturnValue
+    MarkedLocation mark();
 
     int getCharPosition();
 
     String fetchSnippetForException();
+
+    /** Creates an immutable state snapshot. */
+    ParserState snapshot();
+
+    interface MarkedLocation {
+        /**
+         * return to this marked position.
+         */
+        void rewind();
+    }
 }

--- a/conjure-core/src/main/java/com/palantir/parsec/StringParserState.java
+++ b/conjure-core/src/main/java/com/palantir/parsec/StringParserState.java
@@ -16,8 +16,6 @@
 
 package com.palantir.parsec;
 
-import java.util.ArrayDeque;
-import java.util.Deque;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -26,7 +24,6 @@ public final class StringParserState implements ParserState {
     private static final int SNIPPET_HEIGHT = 5;
 
     private final CharSequence seq;
-    private final Deque<Integer> marks = new ArrayDeque<>();
     private int current = 0;
 
     public StringParserState(CharSequence str) {
@@ -47,18 +44,9 @@ public final class StringParserState implements ParserState {
     }
 
     @Override
-    public void mark() {
-        marks.push(current);
-    }
-
-    @Override
-    public void rewind() {
-        current = marks.pop();
-    }
-
-    @Override
-    public void release() {
-        marks.pop();
+    public MarkedLocation mark() {
+        int markedPosition = current;
+        return () -> current = markedPosition;
     }
 
     @Override
@@ -109,5 +97,12 @@ public final class StringParserState implements ParserState {
                     return prefix + segment + suffix;
                 })
                 .collect(Collectors.joining("\n"));
+    }
+
+    @Override
+    public ParserState snapshot() {
+        StringParserState snapshot = new StringParserState(seq);
+        snapshot.current = current;
+        return snapshot;
     }
 }

--- a/conjure-core/src/main/java/com/palantir/parsec/parsers/BetweenParser.java
+++ b/conjure-core/src/main/java/com/palantir/parsec/parsers/BetweenParser.java
@@ -19,6 +19,7 @@ package com.palantir.parsec.parsers;
 import com.palantir.parsec.ParseException;
 import com.palantir.parsec.Parser;
 import com.palantir.parsec.ParserState;
+import com.palantir.parsec.ParserState.MarkedLocation;
 import com.palantir.parsec.Parsers;
 
 public final class BetweenParser<T> implements Parser<T> {
@@ -40,12 +41,11 @@ public final class BetweenParser<T> implements Parser<T> {
 
         // First, consume the thing you expect to find at the beginning.
         // This is likely to be a string constant like "{".
-        input.mark();
+        MarkedLocation mark = input.mark();
         if (Parsers.nullOrUnexpected(start.parse(input))) {
-            input.rewind();
+            mark.rewind();
             throw new ParseException("Expected start token " + start.description() + " for " + description, input);
         }
-        input.release();
 
         // Then, consume the thing you expect to find in the middle.
         // This is likely to be done with a more complicated parser
@@ -58,12 +58,11 @@ public final class BetweenParser<T> implements Parser<T> {
 
         // Finally, consume the thing you expect to find at the end.
         // This is likely to be a string constant like "}".
-        input.mark();
+        mark = input.mark();
         if (Parsers.nullOrUnexpected(end.parse(input))) {
-            input.rewind();
+            mark.rewind();
             throw new ParseException("Expected end token " + end.description() + " for " + description, input);
         }
-        input.release();
 
         // The thing we care about was in the middle.
         // Parser<?>, and return the T.)

--- a/conjure-core/src/test/java/com/palantir/conjure/parser/ImportSetPrefixTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/parser/ImportSetPrefixTest.java
@@ -1,0 +1,36 @@
+/*
+ * (c) Copyright 2019 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.parser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableSet;
+import com.palantir.conjure.defs.Conjure;
+import com.palantir.conjure.spec.ConjureDefinition;
+import java.io.File;
+import org.junit.jupiter.api.Test;
+
+public class ImportSetPrefixTest {
+
+    @Test
+    public void parsesImportsWithWrapperPrefixes() {
+        ConjureDefinition normalized =
+                Conjure.parse(ImmutableSet.of(new File("src/test/resources/import-set-prefix.yml")));
+        assertThat(normalized.getErrors()).hasSize(1);
+        assertThat(normalized.getTypes()).hasSize(2);
+    }
+}

--- a/conjure-core/src/test/resources/import-set-prefix-target.yml
+++ b/conjure-core/src/test/resources/import-set-prefix-target.yml
@@ -1,0 +1,7 @@
+types:
+  definitions:
+    default-package: com.palantir.a
+    objects:
+      ImportSetPrefixTarget:
+        package: com.palantir.a
+        alias: string

--- a/conjure-core/src/test/resources/import-set-prefix.yml
+++ b/conjure-core/src/test/resources/import-set-prefix.yml
@@ -1,0 +1,16 @@
+types:
+  conjure-imports:
+    settings: import-set-prefix-target.yml
+  definitions:
+    default-package: com.palantir.a
+    objects:
+      ImportSetPrefixObject:
+        package: com.palantir.a
+        fields:
+          first: settings.ImportSetPrefixTarget
+    errors:
+      ImportSetPrefixError:
+        namespace: Test
+        code: INVALID_ARGUMENT
+        safe-args:
+          first: settings.ImportSetPrefixTarget


### PR DESCRIPTION
Previously importing conjure objects using a reference along the
lines of `settings.Foo` would fail because it would match the
`set` prefix. Now we handle it correctly.

This introduces a change to the way parser markers work:
Instead of maintaining a mark/rewind/release stack, the mark
method returns an object which can be used to return to the
marked location, and the `release` functionality is no longer
necessarily. This takes advantage of the application stack
rather than maintaining a separate stack that can get out of
sync.

==COMMIT_MSG==
Fix references with container prefixes `set`/`list`/`optional`
==COMMIT_MSG==
