### PR TITLE
Conjure types may be declared with log-safety

### DIFF
--- a/changelog/@unreleased/pr-1140.v2.yml
+++ b/changelog/@unreleased/pr-1140.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: Conjure types may be declared with log-safety. Only conjure primitives
+    (and wrappers around these primitives) may declare safety, complex types calculate
+    safety based on the type graph.
+  links:
+  - https://github.com/palantir/conjure/pull/1140

--- a/conjure-api/build.gradle
+++ b/conjure-api/build.gradle
@@ -35,4 +35,11 @@ conjure {
     typescript {
         nodeCompatibleModules = true
     }
+    java {
+        // Avoid warnings when java code is generated
+        useImmutableBytes = true
+        // Empty optionals are excluded from serialization by default,
+        // allowing for seamless rollout of new experimental features.
+        excludeEmptyOptionals = true
+    }
 }

--- a/conjure-api/src/main/conjure/conjure-api.yml
+++ b/conjure-api/src/main/conjure/conjure-api.yml
@@ -26,6 +26,20 @@ types:
       Documentation:
         alias: string
 
+      LogSafety:
+        docs: >
+          Safety with regards to logging based on [safe-logging](https://github.com/palantir/safe-logging) concepts.
+        values:
+          - value: SAFE
+            docs: Explicitly marks an element as safe.
+          - value: UNSAFE
+            docs: Explicitly marks an element as unsafe, diallowing contents from being logged as `SAFE`.
+          - value: DO_NOT_LOG
+            docs: >
+              Marks elements that must never be logged.
+              For example, credentials, keys, and other secrets cannot be logged because such an action would
+              compromise security.
+
       # errors
       ErrorNamespace:
         alias: string
@@ -111,6 +125,7 @@ types:
           typeName: TypeName
           alias: Type
           docs: optional<Documentation>
+          safety: optional<LogSafety>
       EnumDefinition:
         fields:
           typeName: TypeName
@@ -137,6 +152,7 @@ types:
           type: Type
           docs: optional<Documentation>
           deprecated: optional<Documentation>
+          safety: optional<LogSafety>
       FieldName:
         alias: string
         docs: Should be in lowerCamelCase, but kebab-case and snake_case are also permitted.

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/ConjureDefinitionValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/ConjureDefinitionValidator.java
@@ -53,7 +53,8 @@ public enum ConjureDefinitionValidator implements ConjureValidator<ConjureDefini
     NO_RECURSIVE_TYPES(new NoRecursiveTypesValidator()),
     UNIQUE_NAMES(new UniqueNamesValidator()),
     NO_NESTED_OPTIONAL(new NoNestedOptionalValidator()),
-    ILLEGAL_MAP_KEYS(new IllegalMapKeyValidator());
+    ILLEGAL_MAP_KEYS(new IllegalMapKeyValidator()),
+    LOG_SAFETY(new LogSafetyConjureDefinitionValidator());
 
     public static void validateAll(ConjureDefinition definition) {
         for (ConjureValidator<ConjureDefinition> validator : values()) {
@@ -426,6 +427,15 @@ public enum ConjureDefinitionValidator implements ConjureValidator<ConjureDefini
                                         || subType.accept(TypeVisitor.IS_ANY));
             }
             return false;
+        }
+    }
+
+    @com.google.errorprone.annotations.Immutable
+    private static final class LogSafetyConjureDefinitionValidator implements ConjureValidator<ConjureDefinition> {
+
+        @Override
+        public void validate(ConjureDefinition definition) {
+            definition.getTypes().forEach(SafetyValidator::validate);
         }
     }
 }

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/ErrorDefinitionValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/ErrorDefinitionValidator.java
@@ -44,8 +44,7 @@ public final class ErrorDefinitionValidator {
         if (!fieldsDeclaringSafety.isEmpty()) {
             throw new ConjureIllegalStateException("ErrorDefinition field safety is defined by the key 'safeArgs' or "
                     + "'unsafeArgs', safety cannot be declared: "
-                    + fieldsDeclaringSafety);
+                    + fieldsDeclaringSafety + " in error " + definition.getErrorName());
         }
-        // TODO(ckozak): Resolve safety of all referenced types to ensure alignment with the encapsulating field.
     }
 }

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/SafetyValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/SafetyValidator.java
@@ -114,7 +114,9 @@ public final class SafetyValidator {
         @Override
         public Void visitMap(MapType map) {
             throw new ConjureIllegalStateException(
-                    String.format("%s cannot declare log safety. Maps are not supported at this time.", map));
+                    "Maps cannot declare log safety. Consider using alias types for keys or values to "
+                            + "leverage the type system. Failing map: "
+                            + map);
         }
 
         @Override

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/SafetyValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/SafetyValidator.java
@@ -1,0 +1,204 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.defs.validator;
+
+import com.palantir.conjure.exceptions.ConjureIllegalStateException;
+import com.palantir.conjure.spec.AliasDefinition;
+import com.palantir.conjure.spec.EnumDefinition;
+import com.palantir.conjure.spec.ExternalReference;
+import com.palantir.conjure.spec.ListType;
+import com.palantir.conjure.spec.LogSafety;
+import com.palantir.conjure.spec.MapType;
+import com.palantir.conjure.spec.ObjectDefinition;
+import com.palantir.conjure.spec.OptionalType;
+import com.palantir.conjure.spec.PrimitiveType;
+import com.palantir.conjure.spec.SetType;
+import com.palantir.conjure.spec.Type;
+import com.palantir.conjure.spec.TypeDefinition;
+import com.palantir.conjure.spec.TypeName;
+import com.palantir.conjure.spec.UnionDefinition;
+import java.util.Optional;
+
+public final class SafetyValidator {
+
+    private SafetyValidator() {}
+
+    public static void validate(TypeDefinition type) {
+        type.accept(TypeDefinitionSafetyVisitor.INSTANCE);
+    }
+
+    private static ConjureIllegalStateException fail(Object typeDescription) {
+        return new ConjureIllegalStateException(String.format(
+                "%s cannot declare log safety. Only conjure primitives and "
+                        + "wrappers around conjure primitives may declare safety.",
+                typeDescription));
+    }
+
+    private enum TypeDefinitionSafetyVisitor implements TypeDefinition.Visitor<Void> {
+        INSTANCE;
+
+        @Override
+        public Void visitAlias(AliasDefinition value) {
+            validateType(value.getAlias(), value.getSafety());
+            return null;
+        }
+
+        @Override
+        public Void visitEnum(EnumDefinition _value) {
+            return null;
+        }
+
+        @Override
+        public Void visitObject(ObjectDefinition value) {
+            value.getFields().forEach(field -> validateType(field.getType(), field.getSafety()));
+            return null;
+        }
+
+        @Override
+        public Void visitUnion(UnionDefinition value) {
+            value.getUnion().forEach(field -> validateType(field.getType(), field.getSafety()));
+            return null;
+        }
+
+        @Override
+        public Void visitUnknown(String unknownType) {
+            throw new ConjureIllegalStateException("Unknown type: " + unknownType);
+        }
+
+        private static void validateType(Type type, Optional<LogSafety> declaredSafety) {
+            if (declaredSafety.isPresent()) {
+                type.accept(SafetyTypeVisitor.INSTANCE);
+            }
+        }
+    }
+
+    /** Validates elements which declare safety. Fails if any non-primitive is referenced. */
+    private enum SafetyTypeVisitor implements Type.Visitor<Void> {
+        INSTANCE;
+
+        @Override
+        public Void visitPrimitive(PrimitiveType value) {
+            value.accept(PrimitiveTypeSafetyVisitor.INSTANCE);
+            return null;
+        }
+
+        @Override
+        public Void visitOptional(OptionalType value) {
+            return value.getItemType().accept(this);
+        }
+
+        @Override
+        public Void visitList(ListType value) {
+            return value.getItemType().accept(this);
+        }
+
+        @Override
+        public Void visitSet(SetType value) {
+            return value.getItemType().accept(this);
+        }
+
+        @Override
+        public Void visitMap(MapType map) {
+            throw new ConjureIllegalStateException(
+                    String.format("%s cannot declare log safety. Maps are not supported at this time.", map));
+        }
+
+        @Override
+        public Void visitReference(TypeName value) {
+            throw fail(value);
+        }
+
+        @Override
+        public Void visitExternal(ExternalReference value) {
+            throw fail(value.getExternalReference());
+        }
+
+        @Override
+        public Void visitUnknown(String unknownType) {
+            throw new ConjureIllegalStateException("Unknown type: " + unknownType);
+        }
+    }
+
+    /**
+     * Validates elements which declare safety. Fails if any non-primitive is referenced.
+     * Ensures bearer-token safety cannot be overridden from {@code do-not-log}.
+     */
+    private enum PrimitiveTypeSafetyVisitor implements PrimitiveType.Visitor<Void> {
+        INSTANCE;
+
+        @Override
+        public Void visitString() {
+            return null;
+        }
+
+        @Override
+        public Void visitDatetime() {
+            return null;
+        }
+
+        @Override
+        public Void visitInteger() {
+            return null;
+        }
+
+        @Override
+        public Void visitDouble() {
+            return null;
+        }
+
+        @Override
+        public Void visitSafelong() {
+            return null;
+        }
+
+        @Override
+        public Void visitBinary() {
+            return null;
+        }
+
+        @Override
+        public Void visitAny() {
+            return null;
+        }
+
+        @Override
+        public Void visitBoolean() {
+            return null;
+        }
+
+        @Override
+        public Void visitUuid() {
+            return null;
+        }
+
+        @Override
+        public Void visitRid() {
+            return null;
+        }
+
+        @Override
+        public Void visitBearertoken() {
+            throw new ConjureIllegalStateException(
+                    "bearertoken values are do-not-log by default and cannot be configured");
+        }
+
+        @Override
+        public Void visitUnknown(String unknownValue) {
+            throw new ConjureIllegalStateException("Unknown primitive type: " + unknownValue);
+        }
+    }
+}

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/LogSafetyDefinition.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/LogSafetyDefinition.java
@@ -1,0 +1,52 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.parser;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonCreator.Mode;
+import com.palantir.conjure.exceptions.ConjureIllegalArgumentException;
+import com.palantir.logsafe.Preconditions;
+
+public enum LogSafetyDefinition {
+    SAFE("safe"),
+    UNSAFE("unsafe"),
+    DO_NOT_LOG("do-not-log");
+
+    private final String name;
+
+    LogSafetyDefinition(String name) {
+        this.name = name;
+    }
+
+    @JsonCreator(mode = Mode.DELEGATING)
+    public static LogSafetyDefinition parse(String value) {
+        switch (Preconditions.checkNotNull(value, "String value is required")) {
+            case "safe":
+                return SAFE;
+            case "unsafe":
+                return UNSAFE;
+            case "do-not-log":
+                return DO_NOT_LOG;
+        }
+        throw new ConjureIllegalArgumentException("Unknown value: " + value);
+    }
+
+    @Override
+    public String toString() {
+        return "LogSafetyDefinition{" + name + '}';
+    }
+}

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/types/complex/FieldDefinition.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/types/complex/FieldDefinition.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.palantir.conjure.defs.ConjureImmutablesStyle;
+import com.palantir.conjure.parser.LogSafetyDefinition;
 import com.palantir.conjure.parser.types.ConjureType;
 import com.palantir.conjure.parser.types.complex.FieldDefinition.FieldDefinitionDeserializer;
 import com.palantir.parsec.ParseException;
@@ -38,6 +39,8 @@ public interface FieldDefinition {
     Optional<String> docs();
 
     Optional<String> deprecated();
+
+    Optional<LogSafetyDefinition> safety();
 
     static FieldDefinition of(ConjureType type) {
         return ImmutableFieldDefinition.builder().type(type).build();

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/types/reference/AliasTypeDefinition.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/types/reference/AliasTypeDefinition.java
@@ -20,10 +20,12 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.TreeNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.palantir.conjure.defs.ConjureImmutablesStyle;
+import com.palantir.conjure.parser.LogSafetyDefinition;
 import com.palantir.conjure.parser.types.BaseObjectTypeDefinition;
 import com.palantir.conjure.parser.types.ConjureType;
 import com.palantir.conjure.parser.types.TypeDefinitionVisitor;
 import java.io.IOException;
+import java.util.Optional;
 import org.immutables.value.Value;
 
 @JsonDeserialize(as = ImmutableAliasTypeDefinition.class)
@@ -32,6 +34,8 @@ import org.immutables.value.Value;
 public interface AliasTypeDefinition extends BaseObjectTypeDefinition {
 
     ConjureType alias();
+
+    Optional<LogSafetyDefinition> safety();
 
     @Override
     default <T> T visit(TypeDefinitionVisitor<T> visitor) {

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ConjureSourceFileValidatorTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ConjureSourceFileValidatorTest.java
@@ -295,7 +295,7 @@ public class ConjureSourceFileValidatorTest {
                 .build();
         assertThatThrownBy(() -> ConjureDefinitionValidator.validateAll(conjureDef))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("Maps are not supported at this time");
+                .hasMessageContainingAll("Maps cannot declare log safety", "Consider using alias types");
     }
 
     @Test

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ConjureSourceFileValidatorTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ConjureSourceFileValidatorTest.java
@@ -31,6 +31,7 @@ import com.palantir.conjure.spec.FieldName;
 import com.palantir.conjure.spec.HttpMethod;
 import com.palantir.conjure.spec.HttpPath;
 import com.palantir.conjure.spec.ListType;
+import com.palantir.conjure.spec.LogSafety;
 import com.palantir.conjure.spec.MapType;
 import com.palantir.conjure.spec.ObjectDefinition;
 import com.palantir.conjure.spec.OptionalType;
@@ -232,6 +233,86 @@ public class ConjureSourceFileValidatorTest {
         assertThatThrownBy(() -> ConjureDefinitionValidator.ILLEGAL_MAP_KEYS.validate(conjureDef))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageStartingWith("Illegal map key found in object Foo");
+    }
+
+    @Test
+    public void testNoSafetyOnComplexTypes() {
+        ConjureDefinition conjureDef = ConjureDefinition.builder()
+                .version(1)
+                .types(TypeDefinition.alias(AliasDefinition.builder()
+                        .typeName(TypeName.of("AliasName", "package"))
+                        .alias(Type.list(ListType.of(Type.primitive(PrimitiveType.STRING))))
+                        .build()))
+                .types(TypeDefinition.object(ObjectDefinition.builder()
+                        .typeName(FOO)
+                        .fields(FieldDefinition.builder()
+                                .fieldName(FieldName.of("bad"))
+                                .type(Type.reference(TypeName.of("AliasName", "package")))
+                                .safety(LogSafety.UNSAFE)
+                                .docs(DOCS)
+                                .build())
+                        .build()))
+                .build();
+        assertThatThrownBy(() -> ConjureDefinitionValidator.validateAll(conjureDef))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining(
+                        "Only conjure primitives and wrappers around conjure primitives may declare safety");
+    }
+
+    @Test
+    public void testSafetyOnBearerToken() {
+        ConjureDefinition conjureDef = ConjureDefinition.builder()
+                .version(1)
+                .types(TypeDefinition.object(ObjectDefinition.builder()
+                        .typeName(FOO)
+                        .fields(FieldDefinition.builder()
+                                .fieldName(FieldName.of("bad"))
+                                .type(Type.primitive(PrimitiveType.BEARERTOKEN))
+                                .safety(LogSafety.DO_NOT_LOG)
+                                .docs(DOCS)
+                                .build())
+                        .build()))
+                .build();
+        assertThatThrownBy(() -> ConjureDefinitionValidator.validateAll(conjureDef))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("do-not-log by default and cannot be configured");
+    }
+
+    @Test
+    public void testSafetyOnMap() {
+        ConjureDefinition conjureDef = ConjureDefinition.builder()
+                .version(1)
+                .types(TypeDefinition.object(ObjectDefinition.builder()
+                        .typeName(FOO)
+                        .fields(FieldDefinition.builder()
+                                .fieldName(FieldName.of("bad"))
+                                .type(Type.map(MapType.of(
+                                        Type.primitive(PrimitiveType.STRING), Type.primitive(PrimitiveType.STRING))))
+                                .safety(LogSafety.DO_NOT_LOG)
+                                .docs(DOCS)
+                                .build())
+                        .build()))
+                .build();
+        assertThatThrownBy(() -> ConjureDefinitionValidator.validateAll(conjureDef))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Maps are not supported at this time");
+    }
+
+    @Test
+    public void testNoSafetyOnPrimitive() {
+        ConjureDefinition conjureDef = ConjureDefinition.builder()
+                .version(1)
+                .types(TypeDefinition.object(ObjectDefinition.builder()
+                        .typeName(FOO)
+                        .fields(FieldDefinition.builder()
+                                .fieldName(FieldName.of("bad"))
+                                .type(Type.primitive(PrimitiveType.STRING))
+                                .safety(LogSafety.UNSAFE)
+                                .docs(DOCS)
+                                .build())
+                        .build()))
+                .build();
+        ConjureDefinitionValidator.validateAll(conjureDef);
     }
 
     private FieldDefinition field(FieldName name, String type) {

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/validator/EndpointDefinitionTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/validator/EndpointDefinitionTest.java
@@ -140,10 +140,11 @@ public final class EndpointDefinitionTest {
 
         DealiasingTypeVisitor dealiasingVisitor = new DealiasingTypeVisitor(ImmutableMap.of(
                 typeName,
-                TypeDefinition.alias(AliasDefinition.of(
-                        typeName,
-                        Type.optional(OptionalType.of(Type.primitive(PrimitiveType.BINARY))),
-                        Documentation.of("")))));
+                TypeDefinition.alias(AliasDefinition.builder()
+                        .typeName(typeName)
+                        .alias(Type.optional(OptionalType.of(Type.primitive(PrimitiveType.BINARY))))
+                        .docs(Documentation.of(""))
+                        .build())));
 
         assertThatThrownBy(() -> EndpointDefinitionValidator.validateAll(definition, dealiasingVisitor))
                 .isInstanceOf(IllegalStateException.class)

--- a/conjure-core/src/test/resources/normalized.conjure.json
+++ b/conjure-core/src/test/resources/normalized.conjure.json
@@ -5,7 +5,6 @@
       "name" : "Error1",
       "package" : "com.palantir.a"
     },
-    "docs" : null,
     "namespace" : "Test",
     "code" : "INVALID_ARGUMENT",
     "safeArgs" : [ {
@@ -13,9 +12,7 @@
       "type" : {
         "type" : "primitive",
         "primitive" : "INTEGER"
-      },
-      "docs" : null,
-      "deprecated" : null
+      }
     } ],
     "unsafeArgs" : [ ]
   }, {
@@ -23,7 +20,6 @@
       "name" : "Error2",
       "package" : "com.palantir.a"
     },
-    "docs" : null,
     "namespace" : "Test",
     "code" : "INVALID_ARGUMENT",
     "safeArgs" : [ {
@@ -31,9 +27,7 @@
       "type" : {
         "type" : "primitive",
         "primitive" : "INTEGER"
-      },
-      "docs" : null,
-      "deprecated" : null
+      }
     } ],
     "unsafeArgs" : [ ]
   } ],
@@ -49,11 +43,8 @@
         "type" : {
           "type" : "primitive",
           "primitive" : "STRING"
-        },
-        "docs" : null,
-        "deprecated" : null
-      } ],
-      "docs" : null
+        }
+      } ]
     }
   }, {
     "type" : "alias",
@@ -65,8 +56,7 @@
       "alias" : {
         "type" : "primitive",
         "primitive" : "STRING"
-      },
-      "docs" : null
+      }
     }
   }, {
     "type" : "alias",
@@ -78,8 +68,7 @@
       "alias" : {
         "type" : "primitive",
         "primitive" : "STRING"
-      },
-      "docs" : null
+      }
     }
   } ],
   "services" : [ {
@@ -91,15 +80,10 @@
       "endpointName" : "get",
       "httpMethod" : "GET",
       "httpPath" : "/get",
-      "auth" : null,
       "args" : [ ],
-      "returns" : null,
-      "docs" : null,
-      "deprecated" : null,
       "markers" : [ ],
       "tags" : [ ]
-    } ],
-    "docs" : null
+    } ]
   }, {
     "serviceName" : {
       "name" : "TestService2",
@@ -109,15 +93,10 @@
       "endpointName" : "get",
       "httpMethod" : "GET",
       "httpPath" : "/get",
-      "auth" : null,
       "args" : [ ],
-      "returns" : null,
-      "docs" : null,
-      "deprecated" : null,
       "markers" : [ ],
       "tags" : [ ]
-    } ],
-    "docs" : null
+    } ]
   } ],
   "extensions" : { }
 }

--- a/docs/spec/conjure_definitions.md
+++ b/docs/spec/conjure_definitions.md
@@ -169,11 +169,12 @@ uuid
 [AliasDefinition]: #aliasdefinition
 Definition for an alias complex data type.
 
-Field | Type | Description
----|:---:|---
+Field |      Type       | Description
+---|:---------------:|---
 alias | [ConjureType][] | **REQUIRED**. The Conjure type to be aliased.
-docs | [DocString][] | Documentation for the type. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
-package | `string` | **REQUIRED** if `default-package` is not specified. Overrides the `default-package` in [NamedTypesDefinition][].
+safety |  [LogSafety][]  | The safety of the type in regards to logging in accordance with the SLS specification. Allowed values are `safe`, `unsafe`, and `do-not-log`. Only conjure primitivies,and wrappers around conjure primitives may declare safety, the safety of complex types is computed based on the type graph.
+docs |  [DocString][]  | Documentation for the type. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
+package |    `string`     | **REQUIRED** if `default-package` is not specified. Overrides the `default-package` in [NamedTypesDefinition][].
 
 
 ## ObjectTypeDefinition
@@ -205,11 +206,12 @@ TypeAlias:
 [FieldDefinition]: #fielddefinition
 Definition for a field in a complex data type.
 
-Field | Type | Description
----|:---:|---
+Field |      Type       | Description
+---|:---------------:|---
 type | [ConjureType][] | **REQUIRED**. The name of the type of the field. It MUST be a type name that exists within the Conjure definition.
-docs | [DocString][] | Documentation for the type. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
-deprecated | [DocString][] | Documentation for why this field is deprecated. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
+safety |  [LogSafety][]  | The safety of the type in regards to logging in accordance with the SLS specification. Allowed values are `safe`, `unsafe`, and `do-not-log`. Only conjure primitivies,and wrappers around conjure primitives may declare safety, the safety of complex types is computed based on the type graph.
+docs |  [DocString][]  | Documentation for the type. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
+deprecated |  [DocString][]  | Documentation for why this field is deprecated. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 
 
 ## UnionTypeDefinition


### PR DESCRIPTION
## Before this PR
No real concept of safety aside from hand-waving in ErrorDefinition.

## After this PR
==COMMIT_MSG==
Conjure types may be declared with log-safety. Only conjure primitives (and wrappers around these primitives) may declare safety, complex types calculate safety based on the type graph.
==COMMIT_MSG==

## Possible downsides?
`Map` is not supported at this point, unless the keys and values are wrapped with some other type (Alias).
The current implementation doesn't support declaring safety of external type imports, they're a bit harder to handle due to to lack of information when the IR is compiled.
