### PR TITLE
Better error message for incorrect usage of the safety field

### DIFF
--- a/changelog/@unreleased/pr-1170.v2.yml
+++ b/changelog/@unreleased/pr-1170.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Improve incorrect safety usage error message to reference proper type.
+  links:
+  - https://github.com/palantir/conjure/pull/1170

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/ConjureDefinitionValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/ConjureDefinitionValidator.java
@@ -441,9 +441,7 @@ public enum ConjureDefinitionValidator implements ConjureValidator<ConjureDefini
                     .forEach(endpointDefinition -> endpointDefinition.getArgs().forEach(argumentDefinition -> {
                         try {
                             SafetyValidator.validateDefinition(
-                                    endpointDefinition.getEndpointName(),
-                                    argumentDefinition.getSafety(),
-                                    argumentDefinition.getType());
+                                    endpointDefinition, argumentDefinition.getSafety(), argumentDefinition.getType());
                         } catch (RuntimeException e) {
                             throw new ConjureIllegalStateException(
                                     String.format(

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/ConjureDefinitionValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/ConjureDefinitionValidator.java
@@ -441,7 +441,9 @@ public enum ConjureDefinitionValidator implements ConjureValidator<ConjureDefini
                     .forEach(endpointDefinition -> endpointDefinition.getArgs().forEach(argumentDefinition -> {
                         try {
                             SafetyValidator.validateDefinition(
-                                    argumentDefinition.getSafety(), argumentDefinition.getType());
+                                    endpointDefinition.getEndpointName(),
+                                    argumentDefinition.getSafety(),
+                                    argumentDefinition.getType());
                         } catch (RuntimeException e) {
                             throw new ConjureIllegalStateException(
                                     String.format(

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/SafetyValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/SafetyValidator.java
@@ -18,7 +18,7 @@ package com.palantir.conjure.defs.validator;
 
 import com.palantir.conjure.exceptions.ConjureIllegalStateException;
 import com.palantir.conjure.spec.AliasDefinition;
-import com.palantir.conjure.spec.EndpointName;
+import com.palantir.conjure.spec.EndpointDefinition;
 import com.palantir.conjure.spec.EnumDefinition;
 import com.palantir.conjure.spec.ExternalReference;
 import com.palantir.conjure.spec.FieldName;
@@ -43,16 +43,18 @@ public final class SafetyValidator {
         type.accept(TypeDefinitionSafetyVisitor.INSTANCE);
     }
 
-    public static void validateDefinition(EndpointName endpointName, Optional<LogSafety> declaredSafety, Type type) {
+    public static void validateDefinition(
+            EndpointDefinition endpointDefinition, Optional<LogSafety> declaredSafety, Type type) {
         if (declaredSafety.isPresent()) {
-            type.accept(new SafetyTypeVisitor(endpointName.get()));
+            type.accept(
+                    new SafetyTypeVisitor(endpointDefinition.getEndpointName().get()));
         }
     }
 
     private static ConjureIllegalStateException fail(String parentReference, TypeName nonPrimitiveType) {
         return new ConjureIllegalStateException(String.format(
                 "%s cannot declare log safety. Only conjure primitives and "
-                        + "wrappers around conjure primitives may declare safety. %s.%s is not a primitive type",
+                        + "wrappers around conjure primitives may declare safety. %s.%s is not a primitive type.",
                 parentReference, nonPrimitiveType.getPackage(), nonPrimitiveType.getName()));
     }
 

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/SafetyValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/SafetyValidator.java
@@ -104,7 +104,7 @@ public final class SafetyValidator {
         }
 
         private static String qualifyTypeReference(TypeName typeName, FieldName fieldName) {
-            return String.format("%s.%s::%s", typeName.getPackage(), typeName.getName(), fieldName);
+            return typeName.getPackage() + '.' + typeName.getName() + "::" + fieldName;
         }
 
         private static String qualifyTypeReference(TypeName typeName) {

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/SafetyValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/SafetyValidator.java
@@ -108,7 +108,7 @@ public final class SafetyValidator {
         }
 
         private static String qualifyTypeReference(TypeName typeName) {
-            return String.format("%s.%s", typeName.getPackage(), typeName.getName());
+            return typeName.getPackage() + '.' + typeName.getName();
         }
     }
 

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/SafetyValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/SafetyValidator.java
@@ -18,8 +18,10 @@ package com.palantir.conjure.defs.validator;
 
 import com.palantir.conjure.exceptions.ConjureIllegalStateException;
 import com.palantir.conjure.spec.AliasDefinition;
+import com.palantir.conjure.spec.EndpointName;
 import com.palantir.conjure.spec.EnumDefinition;
 import com.palantir.conjure.spec.ExternalReference;
+import com.palantir.conjure.spec.FieldName;
 import com.palantir.conjure.spec.ListType;
 import com.palantir.conjure.spec.LogSafety;
 import com.palantir.conjure.spec.MapType;
@@ -41,17 +43,17 @@ public final class SafetyValidator {
         type.accept(TypeDefinitionSafetyVisitor.INSTANCE);
     }
 
-    public static void validateDefinition(Optional<LogSafety> declaredSafety, Type type) {
+    public static void validateDefinition(EndpointName endpointName, Optional<LogSafety> declaredSafety, Type type) {
         if (declaredSafety.isPresent()) {
-            type.accept(SafetyTypeVisitor.INSTANCE);
+            type.accept(new SafetyTypeVisitor(endpointName.get()));
         }
     }
 
-    private static ConjureIllegalStateException fail(TypeName typeName) {
+    private static ConjureIllegalStateException fail(String parentReference, TypeName nonPrimitiveType) {
         return new ConjureIllegalStateException(String.format(
-                "%s.%s cannot declare log safety. Only conjure primitives and "
-                        + "wrappers around conjure primitives may declare safety.",
-                typeName.getPackage(), typeName.getName()));
+                "%s cannot declare log safety. Only conjure primitives and "
+                        + "wrappers around conjure primitives may declare safety. %s.%s is not a primitive type",
+                parentReference, nonPrimitiveType.getPackage(), nonPrimitiveType.getName()));
     }
 
     private enum TypeDefinitionSafetyVisitor implements TypeDefinition.Visitor<Void> {
@@ -59,7 +61,7 @@ public final class SafetyValidator {
 
         @Override
         public Void visitAlias(AliasDefinition value) {
-            validateType(value.getAlias(), value.getSafety());
+            validateType(value.getAlias(), value.getSafety(), qualifyTypeReference(value.getTypeName()));
             return null;
         }
 
@@ -70,13 +72,21 @@ public final class SafetyValidator {
 
         @Override
         public Void visitObject(ObjectDefinition value) {
-            value.getFields().forEach(field -> validateType(field.getType(), field.getSafety()));
+            value.getFields()
+                    .forEach(field -> validateType(
+                            field.getType(),
+                            field.getSafety(),
+                            qualifyTypeReference(value.getTypeName(), field.getFieldName())));
             return null;
         }
 
         @Override
         public Void visitUnion(UnionDefinition value) {
-            value.getUnion().forEach(field -> validateType(field.getType(), field.getSafety()));
+            value.getUnion()
+                    .forEach(field -> validateType(
+                            field.getType(),
+                            field.getSafety(),
+                            qualifyTypeReference(value.getTypeName(), field.getFieldName())));
             return null;
         }
 
@@ -85,16 +95,29 @@ public final class SafetyValidator {
             throw new ConjureIllegalStateException("Unknown type: " + unknownType);
         }
 
-        private static void validateType(Type type, Optional<LogSafety> declaredSafety) {
+        private static void validateType(Type type, Optional<LogSafety> declaredSafety, String qualifiedTypeReference) {
             if (declaredSafety.isPresent()) {
-                type.accept(SafetyTypeVisitor.INSTANCE);
+                type.accept(new SafetyTypeVisitor(qualifiedTypeReference));
             }
+        }
+
+        private static String qualifyTypeReference(TypeName typeName, FieldName fieldName) {
+            return String.format("%s.%s::%s", typeName.getPackage(), typeName.getName(), fieldName);
+        }
+
+        private static String qualifyTypeReference(TypeName typeName) {
+            return String.format("%s.%s", typeName.getPackage(), typeName.getName());
         }
     }
 
     /** Validates elements which declare safety. Fails if any non-primitive is referenced. */
-    private enum SafetyTypeVisitor implements Type.Visitor<Void> {
-        INSTANCE;
+    private static final class SafetyTypeVisitor implements Type.Visitor<Void> {
+
+        private final String parentReference;
+
+        SafetyTypeVisitor(String parentReference) {
+            this.parentReference = parentReference;
+        }
 
         @Override
         public Void visitPrimitive(PrimitiveType value) {
@@ -127,12 +150,12 @@ public final class SafetyValidator {
 
         @Override
         public Void visitReference(TypeName value) {
-            throw fail(value);
+            throw fail(parentReference, value);
         }
 
         @Override
         public Void visitExternal(ExternalReference value) {
-            throw fail(value.getExternalReference());
+            throw fail(parentReference, value.getExternalReference());
         }
 
         @Override

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ConjureSourceFileValidatorTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ConjureSourceFileValidatorTest.java
@@ -351,8 +351,8 @@ public class ConjureSourceFileValidatorTest {
         assertThatThrownBy(() -> ConjureDefinitionValidator.validateAll(conjureDef))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining(
-                        "Service.end(arg): package.Foo cannot declare log safety. Only conjure primitives and wrappers"
-                                + " around conjure primitives may declare safety.");
+                        "Service.end(arg): end cannot declare log safety. Only conjure primitives and wrappers around"
+                                + " conjure primitives may declare safety. package.Foo is not a primitive type.");
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
Having the following incorrect conjure def for safety:
```
SomeWrapperForAnAlias:
    safety: unsafe
    alias: SomeAlias
      
SomeAlias:
    alias: string
```
results in the error `package.SomeAlias cannot declare log safety. Only conjure primitives and wrappers around conjure primitives may declare safety.` 

SomeAlias isn't the type declaring safety here.

## After this PR

error message becomes `package.SomeWrapperForAnAlias cannot declare log safety. Only conjure primitives and wrappers around conjure primitives may declare safety. package.AliasName is not a primitive type.`

==COMMIT_MSG==
Improve incorrect safety usage error message to reference proper type.
==COMMIT_MSG==

## Possible downsides?
I wanted a way to reference the field name as well so that if you have 
```
ComplexObject:
  fields:
    field1:
       safety: unsafe
       type: NonPrimitiveType
   ... other fields
```
It references the field in the error. Currently it does that with `package.ComplexObject::field1`. Unsure if there's a better convention for that. I was hesitant to conflict with a package definition.
