### PR TITLE
The parser may enforce safety declarations using `--requireSafety`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,8 @@ import net.ltgt.gradle.errorprone.CheckSeverity
 
 buildscript {
     repositories {
-        gradlePluginPortal() { metadataSources { mavenPom(); ignoreGradleMetadataRedirection() } }
         mavenCentral() { metadataSources { mavenPom(); ignoreGradleMetadataRedirection() } }
+        gradlePluginPortal() { metadataSources { mavenPom(); ignoreGradleMetadataRedirection() } }
     }
 
     dependencies {

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/Conjure.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/Conjure.java
@@ -31,10 +31,23 @@ public final class Conjure {
 
     /**
      * Deserializes {@link ConjureDefinition} from their YAML representations in the given files.
+     *
+     * @deprecated in favor of {@link #parse(ConjureArgs)}
      */
+    @Deprecated
     public static ConjureDefinition parse(Collection<File> files) {
-        Map<String, AnnotatedConjureSourceFile> sourceFiles = ConjureParser.parseAnnotated(files);
-        ConjureDefinition ir = ConjureParserUtils.parseConjureDef(sourceFiles);
+        return parse(ConjureArgs.builder()
+                .definitions(files)
+                .safetyDeclarations(SafetyDeclarationRequirements.ALLOWED)
+                .build());
+    }
+
+    /**
+     * Deserializes {@link ConjureDefinition} from their YAML representations in the given files.
+     */
+    public static ConjureDefinition parse(ConjureArgs args) {
+        Map<String, AnnotatedConjureSourceFile> sourceFiles = ConjureParser.parseAnnotated(args.definitions());
+        ConjureDefinition ir = ConjureParserUtils.parseConjureDef(sourceFiles, args.safetyDeclarations());
         return NormalizeDefinition.normalize(ir);
     }
 }

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureArgs.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureArgs.java
@@ -1,0 +1,38 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.defs;
+
+import java.io.File;
+import java.util.List;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ConjureImmutablesStyle
+public interface ConjureArgs {
+
+    /** Input conjure YAML definition files. */
+    List<File> definitions();
+
+    /** If {@link SafetyDeclarationRequirements#REQUIRED}, all components which allow safety declarations must declare safety. */
+    SafetyDeclarationRequirements safetyDeclarations();
+
+    static Builder builder() {
+        return new Builder();
+    }
+
+    class Builder extends ImmutableConjureArgs.Builder {}
+}

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureArgs.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureArgs.java
@@ -27,7 +27,10 @@ public interface ConjureArgs {
     /** Input conjure YAML definition files. */
     List<File> definitions();
 
-    /** If {@link SafetyDeclarationRequirements#REQUIRED}, all components which allow safety declarations must declare safety. */
+    /**
+     * If {@link SafetyDeclarationRequirements#REQUIRED}, all components
+     * which allow safety declarations must declare safety.
+     */
     SafetyDeclarationRequirements safetyDeclarations();
 
     static Builder builder() {

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureParserUtils.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureParserUtils.java
@@ -206,7 +206,14 @@ public final class ConjureParserUtils {
                 .collect(Collectors.toMap(source -> source.sourceFile().getAbsolutePath(), Function.identity())));
     }
 
+    @Deprecated
     static ConjureDefinition parseConjureDef(Map<String, AnnotatedConjureSourceFile> annotatedParsedDefs) {
+        return parseConjureDef(annotatedParsedDefs, SafetyDeclarationRequirements.ALLOWED);
+    }
+
+    static ConjureDefinition parseConjureDef(
+            Map<String, AnnotatedConjureSourceFile> annotatedParsedDefs,
+            SafetyDeclarationRequirements safetyDeclarations) {
         ImmutableList.Builder<ServiceDefinition> servicesBuilder = ImmutableList.builder();
         ImmutableList.Builder<ErrorDefinition> errorsBuilder = ImmutableList.builder();
         ImmutableList.Builder<TypeDefinition> typesBuilder = ImmutableList.builder();
@@ -252,7 +259,7 @@ public final class ConjureParserUtils {
                 .services(servicesBuilder.build())
                 .build();
 
-        ConjureDefinitionValidator.validateAll(definition);
+        ConjureDefinitionValidator.validateAll(definition, safetyDeclarations);
         return definition;
     }
 

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/SafetyDeclarationRequirements.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/SafetyDeclarationRequirements.java
@@ -1,0 +1,26 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.defs;
+
+public enum SafetyDeclarationRequirements {
+    ALLOWED,
+    REQUIRED;
+
+    public boolean required() {
+        return this == REQUIRED;
+    }
+}

--- a/conjure/src/main/java/com/palantir/conjure/cli/CliConfiguration.java
+++ b/conjure/src/main/java/com/palantir/conjure/cli/CliConfiguration.java
@@ -35,11 +35,14 @@ public abstract class CliConfiguration {
 
     abstract Map<String, Object> extensions();
 
+    abstract boolean requireSafety();
+
     static Builder builder() {
         return new Builder();
     }
 
-    static CliConfiguration create(String input, String outputIrFile, Map<String, Object> extensions) {
+    static CliConfiguration create(
+            String input, String outputIrFile, Map<String, Object> extensions, boolean requireSafety) {
         File inputFile = new File(input);
 
         Collection<File> inputFiles;
@@ -58,6 +61,7 @@ public abstract class CliConfiguration {
                 .inputFiles(inputFiles)
                 .outputIrFile(outputFile)
                 .extensions(extensions)
+                .requireSafety(requireSafety)
                 .build();
     }
 

--- a/conjure/src/test/java/com/palantir/conjure/cli/ConjureCliTest.java
+++ b/conjure/src/test/java/com/palantir/conjure/cli/ConjureCliTest.java
@@ -58,6 +58,7 @@ public final class ConjureCliTest {
                 .inputFiles(ImmutableList.of(inputFile))
                 .outputIrFile(outputFile)
                 .putExtensions("foo", "bar")
+                .requireSafety(false)
                 .build();
         ConjureCli.CompileCommand cmd = new CommandLine(new ConjureCli())
                 .parseArgs(args)
@@ -73,6 +74,7 @@ public final class ConjureCliTest {
         CliConfiguration expectedConfiguration = CliConfiguration.builder()
                 .inputFiles(ImmutableList.of(inputFile))
                 .outputIrFile(outputFile)
+                .requireSafety(false)
                 .build();
         ConjureCli.CompileCommand cmd = new CommandLine(new ConjureCli())
                 .parseArgs(args)
@@ -133,9 +135,21 @@ public final class ConjureCliTest {
                         new File("src/test/resources/complex/api.yml"),
                         new File("src/test/resources/complex/api-2.yml")))
                 .outputIrFile(outputFile)
+                .requireSafety(false)
                 .build();
         ConjureCli.CompileCommand.generate(configuration);
         assertThat(outputFile).exists();
+    }
+
+    @Test
+    public void canRequireSafetyInfo() {
+        CliConfiguration configuration = CliConfiguration.builder()
+                .inputFiles(ImmutableList.of(new File("src/test/resources/complex/api.yml")))
+                .outputIrFile(outputFile)
+                .requireSafety(true)
+                .build();
+        assertThatThrownBy(() -> ConjureCli.CompileCommand.generate(configuration))
+                .hasMessageContaining("must declare log safety");
     }
 
     @Test
@@ -207,6 +221,7 @@ public final class ConjureCliTest {
         CliConfiguration configuration = CliConfiguration.builder()
                 .inputFiles(ImmutableList.of(inputFile))
                 .outputIrFile(folder)
+                .requireSafety(false)
                 .build();
         assertThatThrownBy(() -> ConjureCli.CompileCommand.generate(configuration))
                 .getRootCause()


### PR DESCRIPTION
## Before this PR
No way to lock in the safe goodness once an API is fully declared for log-safety

## After this PR
==COMMIT_MSG==
The parser may enforce safety declarations using `--requireSafety`
==COMMIT_MSG==

## Possible downsides?
We may allow safety declarations on external type imports in the future, which may cause projects using this option to fail to upgrade, however we shouldn't gate on perfect before we reach good.