### PR TITLE
The `--requireSafety` parameter disallows legacy safety formats

### DIFF
--- a/changelog/@unreleased/pr-1204.v2.yml
+++ b/changelog/@unreleased/pr-1204.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: The `--requireSafety` parameter disallows legacy safety formats
+  links:
+  - https://github.com/palantir/conjure/pull/1204


### PR DESCRIPTION
Previously there were confusing errors when the same safety was
defined twice on the same argument (via generators), and more
confusion when some arguments weren't flagged due to indirect
safety declarations. Now we require standardization on the
`safety` field, and no safety tags/markers when `requireSafety`
is enabled.

==COMMIT_MSG==
The `--requireSafety` parameter disallows legacy safety formats
==COMMIT_MSG==

