### PR TITLE
Add example for complex error parameters

### DIFF
--- a/docs/spec/wire.md
+++ b/docs/spec/wire.md
@@ -349,6 +349,7 @@ Conjure Errors are serialized as JSON objects with the following keys:
           code: NOT_FOUND
           safe-args:
             name: RecipeName
+            numbers: list<integer>
   ```
   Example error type in JSON presentation:
   ```json
@@ -357,7 +358,8 @@ Conjure Errors are serialized as JSON objects with the following keys:
       "errorName": "Recipe:RecipeNotFound",
       "errorInstanceId": "xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx",
       "parameters": {
-          "name": "roasted broccoli with garlic"
+          "name": "roasted broccoli with garlic",
+          "numbers": [1, 2, 3]
       }
   }
   ```


### PR DESCRIPTION
Fixes https://github.com/palantir/conjure/issues/1217

## Before this PR
No example for complex error parameters.  I didn't see it explicitly specified before (see linked issue).

## After this PR
==COMMIT_MSG==
Add example for complex error parameters: a `list<integer>`
==COMMIT_MSG==

## Possible downsides?
Slightly increases size of wire spec document

