### PR TITLE
Report all safety violations

### DIFF
--- a/changelog/@unreleased/pr-1249.v2.yml
+++ b/changelog/@unreleased/pr-1249.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Conjure now reports all safety violations rather than just the first
+    one.
+  links:
+  - https://github.com/palantir/conjure/pull/1249


### PR DESCRIPTION
## Before this PR
Migrating an existing Conjure definition to add safety declarations is a bit cumbersome because only one error is reported at a time. When going through a Conjure definition, it's easy to miss some of the places where safety declarations are required, especially because not all types/arguments accept safety declarations.

## After this PR
Conjure compilation will collect and report all safety violations instead of throwing an errors as soon as a single violation is discovered. This should make it much easier to users to find all the places that are missing safety declarations.