### PR TITLE
UpperCase should allow numbers

### DIFF
--- a/changelog/@unreleased/pr-1273.v2.yml
+++ b/changelog/@unreleased/pr-1273.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Correct schema validation in json schema for enum types
+  links:
+  - https://github.com/palantir/conjure/pull/1273

--- a/conjure.schema.json
+++ b/conjure.schema.json
@@ -515,7 +515,7 @@
       ]
     },
     "UpperCase": {
-      "pattern": "^[A-Z_]+$"
+      "pattern": "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"
     },
     "PascalCase": {
       "type": "string",


### PR DESCRIPTION
Right now this complains on e.g. ACCUMULATOR_V2 because it doesn't like the 2. The replacement is the actual validation that Conjure does.
