### PR TITLE
Intern type names

### DIFF
--- a/conjure-core/src/main/java/com/palantir/conjure/parser/types/names/ConjurePackage.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/types/names/ConjurePackage.java
@@ -58,7 +58,7 @@ public abstract class ConjurePackage {
 
     @JsonCreator
     public static ConjurePackage of(String name) {
-        return ImmutableConjurePackage.builder().name(name).build();
+        return ImmutableConjurePackage.builder().name(Names.intern(name)).build();
     }
 
     public static ConjurePackage of(Iterable<String> components) {

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/types/names/ErrorCode.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/types/names/ErrorCode.java
@@ -62,6 +62,6 @@ public abstract class ErrorCode {
 
     @JsonCreator
     public static ErrorCode of(String name) {
-        return ImmutableErrorCode.builder().name(name).build();
+        return ImmutableErrorCode.builder().name(Names.intern(name)).build();
     }
 }

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/types/names/ErrorNamespace.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/types/names/ErrorNamespace.java
@@ -49,6 +49,6 @@ public abstract class ErrorNamespace {
 
     @JsonCreator
     public static ErrorNamespace of(String name) {
-        return ImmutableErrorNamespace.builder().name(name).build();
+        return ImmutableErrorNamespace.builder().name(Names.intern(name)).build();
     }
 }

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/types/names/FieldName.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/types/names/FieldName.java
@@ -81,7 +81,7 @@ public abstract class FieldName {
 
     @JsonCreator
     public static FieldName of(String name) {
-        return ImmutableFieldName.builder().name(name).build();
+        return ImmutableFieldName.builder().name(Names.intern(name)).build();
     }
 
     /** Converts this {@link FieldName} to a {@link FieldName} with the given case. */

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/types/names/Names.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/types/names/Names.java
@@ -1,0 +1,31 @@
+/*
+ * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.parser.types.names;
+
+import com.google.common.collect.Interner;
+import com.google.common.collect.Interners;
+import javax.annotation.Nullable;
+
+final class Names {
+    private static final Interner<String> internedNames = Interners.newWeakInterner();
+
+    private Names() {}
+
+    static String intern(@Nullable String name) {
+        return (name == null) ? null : internedNames.intern(name);
+    }
+}

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/types/names/Namespace.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/types/names/Namespace.java
@@ -47,6 +47,6 @@ public abstract class Namespace {
 
     @JsonCreator
     public static Namespace of(String name) {
-        return ImmutableNamespace.builder().name(name).build();
+        return ImmutableNamespace.builder().name(Names.intern(name)).build();
     }
 }

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/types/names/TypeName.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/types/names/TypeName.java
@@ -56,6 +56,6 @@ public abstract class TypeName {
 
     @JsonCreator
     public static TypeName of(String name) {
-        return ImmutableTypeName.builder().name(name).build();
+        return ImmutableTypeName.builder().name(Names.intern(name)).build();
     }
 }


### PR DESCRIPTION
## Before this PR
While analyzing an hprof from service running many conjure based services, I noticed many duplicate instances of Conjure `TypeName` strings. While some GC support string duplication, this may not be enabled everywhere (e.g. see https://github.com/palantir/sls-packaging/pull/1380 ) . 

## After this PR
==COMMIT_MSG==
Intern type names
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

