### PR TITLE
Improve invalid key map errors

### DIFF
--- a/changelog/@unreleased/pr-1291.v2.yml
+++ b/changelog/@unreleased/pr-1291.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Improve invalid key map errors to explain map keys can only be primitive
+    Conjure types.
+  links:
+  - https://github.com/palantir/conjure/pull/1291

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/ConjureDefinitionValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/ConjureDefinitionValidator.java
@@ -328,7 +328,8 @@ public enum ConjureDefinitionValidator implements ConjureValidator<ConjureDefini
                         .ifPresent(_arg -> {
                             throw new ConjureIllegalStateException(
                                     "Illegal map key found in one of the arguments of endpoint "
-                                            + endpoint.getEndpointName().get() + ". Map keys can only be primitive Conjure types.");
+                                            + endpoint.getEndpointName().get()
+                                            + ". Map keys can only be primitive Conjure types.");
                         });
                 endpoint.getReturns().ifPresent(returnType -> {
                     if (recursivelyFindIllegalKeys(returnType, definitionMap, false)) {
@@ -346,7 +347,8 @@ public enum ConjureDefinitionValidator implements ConjureValidator<ConjureDefini
                     .findAny()
                     .ifPresent(_arg -> {
                         throw new ConjureIllegalStateException("Illegal map key found in one of arguments of error "
-                                + errorDef.getErrorName().getName() + ". Map keys can only be primitive Conjure types.");
+                                + errorDef.getErrorName().getName()
+                                + ". Map keys can only be primitive Conjure types.");
                     });
         }
 
@@ -373,7 +375,8 @@ public enum ConjureDefinitionValidator implements ConjureValidator<ConjureDefini
                             .findAny()
                             .ifPresent(found -> {
                                 throw new ConjureIllegalStateException(String.format(
-                                        "Illegal map key found in object %s in field %s. Map keys can only be primitive Conjure types.",
+                                        "Illegal map key found in object %s in field %s. Map keys can only be"
+                                                + " primitive Conjure types.",
                                         objectDefinition.getTypeName().getName(),
                                         found.getFieldName().get()));
                             });
@@ -389,7 +392,8 @@ public enum ConjureDefinitionValidator implements ConjureValidator<ConjureDefini
                             .findAny()
                             .ifPresent(found -> {
                                 throw new ConjureIllegalStateException(String.format(
-                                        "Illegal map key found in union %s in member %s. Map keys can only be primitive Conjure types.",
+                                        "Illegal map key found in union %s in member %s. Map keys can only be"
+                                                + " primitive Conjure types.",
                                         unionDefinition.getTypeName().getName(),
                                         found.getFieldName().get()));
                             });

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/ConjureDefinitionValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/ConjureDefinitionValidator.java
@@ -328,12 +328,12 @@ public enum ConjureDefinitionValidator implements ConjureValidator<ConjureDefini
                         .ifPresent(_arg -> {
                             throw new ConjureIllegalStateException(
                                     "Illegal map key found in one of the arguments of endpoint "
-                                            + endpoint.getEndpointName().get());
+                                            + endpoint.getEndpointName().get() + ". Map keys can only be primitive Conjure types.");
                         });
                 endpoint.getReturns().ifPresent(returnType -> {
                     if (recursivelyFindIllegalKeys(returnType, definitionMap, false)) {
                         throw new ConjureIllegalStateException("Illegal map key found in return type of endpoint "
-                                + endpoint.getEndpointName().get());
+                                + endpoint.getEndpointName().get() + ". Map keys can only be primitive Conjure types.");
                     }
                 });
             });
@@ -346,7 +346,7 @@ public enum ConjureDefinitionValidator implements ConjureValidator<ConjureDefini
                     .findAny()
                     .ifPresent(_arg -> {
                         throw new ConjureIllegalStateException("Illegal map key found in one of arguments of error "
-                                + errorDef.getErrorName().getName());
+                                + errorDef.getErrorName().getName() + ". Map keys can only be primitive Conjure types.");
                     });
         }
 
@@ -359,7 +359,7 @@ public enum ConjureDefinitionValidator implements ConjureValidator<ConjureDefini
                     AliasDefinition aliasDef = typeDef.accept(TypeDefinitionVisitor.ALIAS);
                     if (recursivelyFindIllegalKeys(aliasDef.getAlias(), definitionMap, false)) {
                         throw new ConjureIllegalStateException("Illegal map key found in alias "
-                                + aliasDef.getTypeName().getName());
+                                + aliasDef.getTypeName().getName() + ". Map keys can only be primitive Conjure types.");
                     }
                     return null;
                 }
@@ -373,7 +373,7 @@ public enum ConjureDefinitionValidator implements ConjureValidator<ConjureDefini
                             .findAny()
                             .ifPresent(found -> {
                                 throw new ConjureIllegalStateException(String.format(
-                                        "Illegal map key found in object %s in field %s",
+                                        "Illegal map key found in object %s in field %s. Map keys can only be primitive Conjure types.",
                                         objectDefinition.getTypeName().getName(),
                                         found.getFieldName().get()));
                             });
@@ -389,7 +389,7 @@ public enum ConjureDefinitionValidator implements ConjureValidator<ConjureDefini
                             .findAny()
                             .ifPresent(found -> {
                                 throw new ConjureIllegalStateException(String.format(
-                                        "Illegal map key found in union %s in member %s",
+                                        "Illegal map key found in union %s in member %s. Map keys can only be primitive Conjure types.",
                                         unionDefinition.getTypeName().getName(),
                                         found.getFieldName().get()));
                             });

--- a/conjure/src/test/java/com/palantir/conjure/cli/ConjureCliTest.java
+++ b/conjure/src/test/java/com/palantir/conjure/cli/ConjureCliTest.java
@@ -176,7 +176,9 @@ public final class ConjureCliTest {
         ConjureCli.prepareCommand().setErr(printWriter).execute(args);
         printWriter.flush();
         assertThat(stringWriter.toString().trim())
-                .isEqualTo("Illegal map key found in union SimpleUnion in member optionA");
+                .isEqualTo(
+                        "Illegal map key found in union SimpleUnion in member optionA. Map keys can only be primitive"
+                                + " Conjure types.");
         assertThat(outputFile).doesNotExist();
     }
 


### PR DESCRIPTION
## Before this PR
Error is quite obscure: 
`Illegal map key found in object Object in field Field`

## After this PR
==COMMIT_MSG==
Improve invalid key map errors to explain map keys can only be primitive Conjure types.
==COMMIT_MSG==