### PR TITLE
don't fail on external imports

### DIFF
--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/SafetyValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/SafetyValidator.java
@@ -182,8 +182,9 @@ public final class SafetyValidator {
         }
 
         @Override
-        public Stream<String> visitExternal(ExternalReference value) {
-            return Stream.of(fail(parentReference, value.getExternalReference()));
+        public Stream<String> visitExternal(ExternalReference _value) {
+            // ignore safety declarations on external imports
+            return Stream.empty();
         }
 
         @Override

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ConjureSourceFileValidatorTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ConjureSourceFileValidatorTest.java
@@ -511,6 +511,28 @@ public class ConjureSourceFileValidatorTest {
                 .hasMessageContaining("Service.end(arg): Safety markers have been replaced by the 'safety' field");
     }
 
+    @Test
+    public void testSafetyOnExternalImport() {
+        ExternalReference external = ExternalReference.builder()
+                .safety(LogSafety.DO_NOT_LOG)
+                .externalReference(TypeName.of("Long", "java.lang"))
+                .fallback(Type.primitive(PrimitiveType.BOOLEAN))
+                .build();
+        ConjureDefinition conjureDef = ConjureDefinition.builder()
+                .version(1)
+                .types(TypeDefinition.object(ObjectDefinition.builder()
+                        .typeName(FOO)
+                        .fields(FieldDefinition.builder()
+                                .fieldName(FieldName.of("bad"))
+                                .type(Type.external(external))
+                                .safety(LogSafety.UNSAFE)
+                                .docs(DOCS)
+                                .build())
+                        .build()))
+                .build();
+        ConjureDefinitionValidator.validateAll(conjureDef, SafetyDeclarationRequirements.REQUIRED);
+    }
+
     private FieldDefinition field(FieldName name, String type) {
         return FieldDefinition.builder()
                 .fieldName(name)


### PR DESCRIPTION
validation for external imports is performed in internal code, but shouldn't automatically fail in the parser