### PR TITLE
Improve error message for failed case conversion

### DIFF
--- a/conjure-generator-common/src/main/java/com/palantir/conjure/CaseConverter.java
+++ b/conjure-generator-common/src/main/java/com/palantir/conjure/CaseConverter.java
@@ -18,7 +18,6 @@ package com.palantir.conjure;
 
 import com.google.common.base.CaseFormat;
 import com.google.errorprone.annotations.Immutable;
-import java.util.List;
 
 @Immutable
 public final class CaseConverter {
@@ -102,16 +101,6 @@ public final class CaseConverter {
         }
 
         throw new IllegalArgumentException("Unexpected case for: '" + name
-                + "'. Expected to be in one of these case formats: "
-                + List.of(
-                        CaseFormat.UPPER_UNDERSCORE
-                                .converterTo(CaseFormat.LOWER_CAMEL)
-                                .convert(Case.LOWER_CAMEL_CASE.name()),
-                        CaseFormat.UPPER_UNDERSCORE
-                                .converterTo(CaseFormat.LOWER_HYPHEN)
-                                .convert(Case.KEBAB_CASE.name()),
-                        CaseFormat.UPPER_UNDERSCORE
-                                .converterTo(CaseFormat.LOWER_UNDERSCORE)
-                                .convert(Case.SNAKE_CASE.name())));
+                + "'. Expected to be in one of these case formats: [lowerCamelCase, kebab-case, snake_case]");
     }
 }

--- a/conjure-generator-common/src/main/java/com/palantir/conjure/CaseConverter.java
+++ b/conjure-generator-common/src/main/java/com/palantir/conjure/CaseConverter.java
@@ -18,6 +18,7 @@ package com.palantir.conjure;
 
 import com.google.common.base.CaseFormat;
 import com.google.errorprone.annotations.Immutable;
+import java.util.List;
 
 @Immutable
 public final class CaseConverter {
@@ -99,7 +100,18 @@ public final class CaseConverter {
                 return nameCase;
             }
         }
+
         throw new IllegalArgumentException("Unexpected case for: '" + name
-                + "'. Expected one to be in one of these case formats: [lowerCamelCase, kebab-case, snake_case]");
+                + "'. Expected one to be in one of these case formats: "
+                + List.of(
+                        CaseFormat.UPPER_UNDERSCORE
+                                .converterTo(CaseFormat.LOWER_CAMEL)
+                                .convert(Case.LOWER_CAMEL_CASE.name()),
+                        CaseFormat.UPPER_UNDERSCORE
+                                .converterTo(CaseFormat.LOWER_HYPHEN)
+                                .convert(Case.KEBAB_CASE.name()),
+                        CaseFormat.UPPER_UNDERSCORE
+                                .converterTo(CaseFormat.LOWER_UNDERSCORE)
+                                .convert(Case.SNAKE_CASE.name())));
     }
 }

--- a/conjure-generator-common/src/main/java/com/palantir/conjure/CaseConverter.java
+++ b/conjure-generator-common/src/main/java/com/palantir/conjure/CaseConverter.java
@@ -102,7 +102,7 @@ public final class CaseConverter {
         }
 
         throw new IllegalArgumentException("Unexpected case for: '" + name
-                + "'. Expected one to be in one of these case formats: "
+                + "'. Expected to be in one of these case formats: "
                 + List.of(
                         CaseFormat.UPPER_UNDERSCORE
                                 .converterTo(CaseFormat.LOWER_CAMEL)

--- a/conjure-generator-common/src/main/java/com/palantir/conjure/CaseConverter.java
+++ b/conjure-generator-common/src/main/java/com/palantir/conjure/CaseConverter.java
@@ -18,6 +18,8 @@ package com.palantir.conjure;
 
 import com.google.common.base.CaseFormat;
 import com.google.errorprone.annotations.Immutable;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 
 @Immutable
 public final class CaseConverter {
@@ -99,6 +101,8 @@ public final class CaseConverter {
                 return nameCase;
             }
         }
-        throw new IllegalArgumentException("Unexpected case for: " + name);
+        throw new IllegalArgumentException("Unexpected case for: '" + name
+                + "'. Expected one to be in one of these case formats: "
+                + Arrays.stream(Case.values()).map(Enum::name).collect(Collectors.toList()));
     }
 }

--- a/conjure-generator-common/src/main/java/com/palantir/conjure/CaseConverter.java
+++ b/conjure-generator-common/src/main/java/com/palantir/conjure/CaseConverter.java
@@ -18,8 +18,6 @@ package com.palantir.conjure;
 
 import com.google.common.base.CaseFormat;
 import com.google.errorprone.annotations.Immutable;
-import java.util.Arrays;
-import java.util.stream.Collectors;
 
 @Immutable
 public final class CaseConverter {
@@ -102,7 +100,6 @@ public final class CaseConverter {
             }
         }
         throw new IllegalArgumentException("Unexpected case for: '" + name
-                + "'. Expected one to be in one of these case formats: "
-                + Arrays.stream(Case.values()).map(Enum::name).collect(Collectors.toList()));
+                + "'. Expected one to be in one of these case formats: [lowerCamelCase, kebab-case, snake_case]");
     }
 }

--- a/conjure-generator-common/src/test/java/com/palantir/conjure/CaseConverterTest.java
+++ b/conjure-generator-common/src/test/java/com/palantir/conjure/CaseConverterTest.java
@@ -76,10 +76,18 @@ public class CaseConverterTest {
     }
 
     @Test
-    public void testConversionFailure() {
+    public void testConversionFailure_acronym() {
         String nonCase = "myCIDRs";
         assertThatThrownBy(() -> CaseConverter.toCase(nonCase, CaseConverter.Case.KEBAB_CASE))
                 .hasMessage("Unexpected case for: 'myCIDRs'. Expected one to be in one of these case formats: "
+                        + "[lowerCamelCase, kebab-case, snake_case]");
+    }
+
+    @Test
+    public void testConversionFailure_upperSnakeCase() {
+        String nonCase = "UPPER_SNAKE_CASE";
+        assertThatThrownBy(() -> CaseConverter.toCase(nonCase, CaseConverter.Case.KEBAB_CASE))
+                .hasMessage("Unexpected case for: 'UPPER_SNAKE_CASE'. Expected one to be in one of these case formats: "
                         + "[lowerCamelCase, kebab-case, snake_case]");
     }
 }

--- a/conjure-generator-common/src/test/java/com/palantir/conjure/CaseConverterTest.java
+++ b/conjure-generator-common/src/test/java/com/palantir/conjure/CaseConverterTest.java
@@ -17,6 +17,7 @@
 package com.palantir.conjure;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
 
@@ -47,7 +48,7 @@ public class CaseConverterTest {
     }
 
     @Test
-    public void testConversion() throws Exception {
+    public void testConversion() {
         String camelCase = "fooBar";
         String kebabCase = "foo-bar";
         String snakeCase = "foo_bar";
@@ -72,5 +73,13 @@ public class CaseConverterTest {
                 .isEqualTo(kebabCase);
         assertThat(CaseConverter.toCase(snakeCase, CaseConverter.Case.SNAKE_CASE))
                 .isEqualTo(snakeCase);
+    }
+
+    @Test
+    public void testConversionFailure() {
+        String nonCase = "myCIDRs";
+        assertThatThrownBy(() -> CaseConverter.toCase(nonCase, CaseConverter.Case.KEBAB_CASE))
+                .hasMessage("Unexpected case for: 'myCIDRs'. Expected one to be in one of these case formats: "
+                        + "[LOWER_CAMEL_CASE, KEBAB_CASE, SNAKE_CASE]");
     }
 }

--- a/conjure-generator-common/src/test/java/com/palantir/conjure/CaseConverterTest.java
+++ b/conjure-generator-common/src/test/java/com/palantir/conjure/CaseConverterTest.java
@@ -79,7 +79,7 @@ public class CaseConverterTest {
     public void testConversionFailure_acronym() {
         String nonCase = "myCIDRs";
         assertThatThrownBy(() -> CaseConverter.toCase(nonCase, CaseConverter.Case.KEBAB_CASE))
-                .hasMessage("Unexpected case for: 'myCIDRs'. Expected one to be in one of these case formats: "
+                .hasMessage("Unexpected case for: 'myCIDRs'. Expected to be in one of these case formats: "
                         + "[lowerCamelCase, kebab-case, snake_case]");
     }
 
@@ -87,7 +87,7 @@ public class CaseConverterTest {
     public void testConversionFailure_upperSnakeCase() {
         String nonCase = "UPPER_SNAKE_CASE";
         assertThatThrownBy(() -> CaseConverter.toCase(nonCase, CaseConverter.Case.KEBAB_CASE))
-                .hasMessage("Unexpected case for: 'UPPER_SNAKE_CASE'. Expected one to be in one of these case formats: "
+                .hasMessage("Unexpected case for: 'UPPER_SNAKE_CASE'. Expected to be in one of these case formats: "
                         + "[lowerCamelCase, kebab-case, snake_case]");
     }
 }

--- a/conjure-generator-common/src/test/java/com/palantir/conjure/CaseConverterTest.java
+++ b/conjure-generator-common/src/test/java/com/palantir/conjure/CaseConverterTest.java
@@ -80,6 +80,6 @@ public class CaseConverterTest {
         String nonCase = "myCIDRs";
         assertThatThrownBy(() -> CaseConverter.toCase(nonCase, CaseConverter.Case.KEBAB_CASE))
                 .hasMessage("Unexpected case for: 'myCIDRs'. Expected one to be in one of these case formats: "
-                        + "[LOWER_CAMEL_CASE, KEBAB_CASE, SNAKE_CASE]");
+                        + "[lowerCamelCase, kebab-case, snake_case]");
     }
 }


### PR DESCRIPTION
## Before this PR
When attempting to build graphql schema with a field element of `egressCIDRs` this error message appears:
```
Unexpected case for: egressCIDRs
```

I was confused what this meant, and thought it was related to an unhandled switch-case entry.  Instead, it's actually a problem that `egressCIDRs` isn't in a standard casing for conjure, and I fixed by renaming the graphql field to `egressCidrs`.

## After this PR
==COMMIT_MSG==
Improve error message for failed case conversion
==COMMIT_MSG==

The new message is:
```
Unexpected case for: 'myCIDRs'. Expected one to be in one of these case formats: [LOWER_CAMEL_CASE, KEBAB_CASE, SNAKE_CASE]
```

When seeing this, I think I would've been clued in to changing `egressCIDRs` -> `egressCidrs`

## Possible downsides?
Throwing this exception is slightly more expensive now, but this ought not be in any hot paths.