### PR TITLE
Fixing map key validation

### DIFF
--- a/changelog/@unreleased/pr-1448.v2.yml
+++ b/changelog/@unreleased/pr-1448.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fixing map key validation
+  links:
+  - https://github.com/palantir/conjure/pull/1448

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/ConjureDefinitionValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/ConjureDefinitionValidator.java
@@ -420,7 +420,7 @@ public enum ConjureDefinitionValidator implements ConjureValidator<ConjureDefini
                 }
                 return recursivelyFindIllegalKeys(type.accept(TypeVisitor.MAP).getKeyType(), definitionMap, true)
                         || recursivelyFindIllegalKeys(
-                                type.accept(TypeVisitor.MAP).getKeyType(), definitionMap, false);
+                                type.accept(TypeVisitor.MAP).getValueType(), definitionMap, false);
             }
 
             if (isMapKey) {

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ConjureSourceFileValidatorTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ConjureSourceFileValidatorTest.java
@@ -271,29 +271,6 @@ public class ConjureSourceFileValidatorTest {
     }
 
     @Test
-    public void testNoIllegalTypeInsideOptional_IllegalTypeInsideOptional() {
-        ConjureDefinition conjureDef = ConjureDefinition.builder()
-                .version(1)
-                .types(TypeDefinition.object(ObjectDefinition.builder()
-                        .typeName(FOO)
-                        .fields(FieldDefinition.builder()
-                                .fieldName(FieldName.of("bad"))
-                                .type(Type.optional(OptionalType.of(Type.map(MapType.of(
-                                        Type.external(ExternalReference.builder()
-                                                .externalReference(TypeName.of("Foo", "package"))
-                                                .fallback(Type.primitive(PrimitiveType.ANY))
-                                                .build()),
-                                        Type.primitive(PrimitiveType.STRING))))))
-                                .docs(DOCS)
-                                .build())
-                        .build()))
-                .build();
-        assertThatThrownBy(() -> ConjureDefinitionValidator.ILLEGAL_MAP_KEYS.validate(conjureDef))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageStartingWith("Illegal map key found in object Foo");
-    }
-
-    @Test
     public void testNoSafetyOnComplexTypes() {
         ConjureDefinition conjureDef = ConjureDefinition.builder()
                 .version(1)

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ConjureSourceFileValidatorTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ConjureSourceFileValidatorTest.java
@@ -249,6 +249,51 @@ public class ConjureSourceFileValidatorTest {
     }
 
     @Test
+    public void testNoIllegalMapKeys_IllegalKeyInsideMapValue() {
+        ConjureDefinition conjureDef = ConjureDefinition.builder()
+                .version(1)
+                .types(TypeDefinition.object(ObjectDefinition.builder()
+                        .typeName(FOO)
+                        .fields(FieldDefinition.builder()
+                                .fieldName(FieldName.of("bad"))
+                                .type(Type.map(MapType.of(
+                                        Type.primitive(PrimitiveType.STRING),
+                                        Type.map(MapType.of(
+                                                Type.optional(OptionalType.of(Type.primitive(PrimitiveType.STRING))),
+                                                Type.primitive(PrimitiveType.STRING))))))
+                                .docs(DOCS)
+                                .build())
+                        .build()))
+                .build();
+        assertThatThrownBy(() -> ConjureDefinitionValidator.ILLEGAL_MAP_KEYS.validate(conjureDef))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageStartingWith("Illegal map key found in object Foo");
+    }
+
+    @Test
+    public void testNoIllegalTypeInsideOptional_IllegalTypeInsideOptional() {
+        ConjureDefinition conjureDef = ConjureDefinition.builder()
+                .version(1)
+                .types(TypeDefinition.object(ObjectDefinition.builder()
+                        .typeName(FOO)
+                        .fields(FieldDefinition.builder()
+                                .fieldName(FieldName.of("bad"))
+                                .type(Type.optional(OptionalType.of(Type.map(MapType.of(
+                                        Type.external(ExternalReference.builder()
+                                                .externalReference(TypeName.of("Foo", "package"))
+                                                .fallback(Type.primitive(PrimitiveType.ANY))
+                                                .build()),
+                                        Type.primitive(PrimitiveType.STRING))))))
+                                .docs(DOCS)
+                                .build())
+                        .build()))
+                .build();
+        assertThatThrownBy(() -> ConjureDefinitionValidator.ILLEGAL_MAP_KEYS.validate(conjureDef))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageStartingWith("Illegal map key found in object Foo");
+    }
+
+    @Test
     public void testNoSafetyOnComplexTypes() {
         ConjureDefinition conjureDef = ConjureDefinition.builder()
                 .version(1)


### PR DESCRIPTION
## Before this PR
One of the examples of: https://github.com/palantir/conjure/issues/1447

Map key validation didn't recursively look inside map value types correctly.
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
Now it does check inside the map value.
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fixing map key validation
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

