### PR TITLE
Validating types inside optinals

### DIFF
--- a/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ConjureSourceFileValidatorTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ConjureSourceFileValidatorTest.java
@@ -249,6 +249,29 @@ public class ConjureSourceFileValidatorTest {
     }
 
     @Test
+    public void testNoIllegalTypeInsideOptional() {
+        ConjureDefinition conjureDef = ConjureDefinition.builder()
+                .version(1)
+                .types(TypeDefinition.object(ObjectDefinition.builder()
+                        .typeName(FOO)
+                        .fields(FieldDefinition.builder()
+                                .fieldName(FieldName.of("bad"))
+                                .type(Type.optional(OptionalType.of(Type.map(MapType.of(
+                                        Type.external(ExternalReference.builder()
+                                                .externalReference(TypeName.of("Foo", "package"))
+                                                .fallback(Type.primitive(PrimitiveType.ANY))
+                                                .build()),
+                                        Type.primitive(PrimitiveType.STRING))))))
+                                .docs(DOCS)
+                                .build())
+                        .build()))
+                .build();
+        assertThatThrownBy(() -> ConjureDefinitionValidator.ILLEGAL_MAP_KEYS.validate(conjureDef))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageStartingWith("Illegal map key found in object Foo");
+    }
+
+    @Test
     public void testNoSafetyOnComplexTypes() {
         ConjureDefinition conjureDef = ConjureDefinition.builder()
                 .version(1)


### PR DESCRIPTION
## Before this PR
Example of https://github.com/palantir/conjure/issues/1447

Requires a larger refactor, given that we need to do all validations again over the type inside an optional, but validator validates over conjure definitions.

<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

