### PR TITLE
Temporarily Disable TS Publishing

### DIFF
--- a/changelog/@unreleased/pr-1554.v2.yml
+++ b/changelog/@unreleased/pr-1554.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Temporarily Disable TS Publishing
+  links:
+  - https://github.com/palantir/conjure/pull/1554

--- a/conjure-api/build.gradle
+++ b/conjure-api/build.gradle
@@ -29,6 +29,11 @@ project (':conjure-api:conjure-api-typescript') {
     publishTypeScript.doFirst {
         file('src/.npmrc') << "//registry.npmjs.org/:_authToken=${System.env.NPM_AUTH_TOKEN}"
     }
+
+    // The OSS CI images have an exceedingly old version of NPM and this is (likely) causing publishing issues
+    // fortunately (unfortunately) this hasn't successfully published in 2 years so disabling this is a non issue
+    // in the near term, but we do need the java code to continue publishing.
+    publishTypeScript.enabled = false
 }
 
 conjure {


### PR DESCRIPTION
## Before this PR
[TS publishing is failing on develop](https://app.circleci.com/jobs/github/palantir/conjure/15409) due to `429 Too Many Requests - PUT https://registry.npmjs.org/...` Turns out though that this [package hasn't successfully published in years](https://www.npmjs.com/package/conjure-api?activeTab=versions).

## After this PR
Disables the TS publish task so that we can continue publishing the _very_ used java bindings.

## Possible downsides?
Kicks the can down the road, we will need to explore CI image upgrades.

