### PR TITLE
Revert "Temporarily Disable TS Publishing (#1554)"

### DIFF
--- a/changelog/4.44.0/pr-1554.v2.yml
+++ b/changelog/4.44.0/pr-1554.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Temporarily Disable TS Publishing
+  links:
+  - https://github.com/palantir/conjure/pull/1554

--- a/changelog/4.44.0/pr-1554.v2.yml
+++ b/changelog/4.44.0/pr-1554.v2.yml
@@ -1,5 +1,0 @@
-type: fix
-fix:
-  description: Temporarily Disable TS Publishing
-  links:
-  - https://github.com/palantir/conjure/pull/1554

--- a/changelog/@unreleased/pr-1560.v2.yml
+++ b/changelog/@unreleased/pr-1560.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Revert "Temporarily Disable TS Publishing (#1554)"
+  links:
+  - https://github.com/palantir/conjure/pull/1560

--- a/changelog/@unreleased/pr-1560.v2.yml
+++ b/changelog/@unreleased/pr-1560.v2.yml
@@ -1,5 +1,5 @@
 type: improvement
 improvement:
-  description: Revert "Temporarily Disable TS Publishing (#1554)"
+  description: Re-enable typescript publishing
   links:
   - https://github.com/palantir/conjure/pull/1560

--- a/conjure-api/build.gradle
+++ b/conjure-api/build.gradle
@@ -29,11 +29,6 @@ project (':conjure-api:conjure-api-typescript') {
     publishTypeScript.doFirst {
         file('src/.npmrc') << "//registry.npmjs.org/:_authToken=${System.env.NPM_AUTH_TOKEN}"
     }
-
-    // The OSS CI images have an exceedingly old version of NPM and this is (likely) causing publishing issues
-    // fortunately (unfortunately) this hasn't successfully published in 2 years so disabling this is a non issue
-    // in the near term, but we do need the java code to continue publishing.
-    publishTypeScript.enabled = false
 }
 
 conjure {


### PR DESCRIPTION
This reverts commit de91900510b3149aca5c69af68de74bd901b448c.

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Re-enable typescript publishing
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

