### PR TITLE
Setup NPM Token using generateNpmRc Task

### DIFF
--- a/conjure-api/build.gradle
+++ b/conjure-api/build.gradle
@@ -26,9 +26,7 @@ project (':conjure-api:conjure-api-objects') {
 }
 
 project (':conjure-api:conjure-api-typescript') {
-    publishTypeScript.doFirst {
-        file('src/.npmrc') << "//registry.npmjs.org/:_authToken=${System.env.NPM_AUTH_TOKEN}"
-    }
+    generateNpmrc.token = System.env.NPM_AUTH_TOKEN;
 }
 
 conjure {

--- a/conjure-api/build.gradle
+++ b/conjure-api/build.gradle
@@ -26,7 +26,7 @@ project (':conjure-api:conjure-api-objects') {
 }
 
 project (':conjure-api:conjure-api-typescript') {
-    generateNpmrc.token = System.env.NPM_AUTH_TOKEN;
+    generateNpmrc.token = System.env.NPM_AUTH_TOKEN
 }
 
 conjure {

--- a/docs/howto/publish_typescript_to_npm.md
+++ b/docs/howto/publish_typescript_to_npm.md
@@ -1,13 +1,3 @@
 # How to publish TypeScript to npm
 
-If you want to publish npm packages, you need to simulate the `npm login` command to ensure you have the necessary credentials to `npm publish`.  Add the following snippet to your `./your-project-api/build.gradle` to write the `$NPM_AUTH_TOKEN` environment variable to disk.  You should specify this as a secret variable on your CI server (e.g. CircleCI or TravisCI).
-
-```diff
- apply plugin: 'com.palantir.conjure'
-
-+project("${project.name}-typescript") {
-+    publishTypeScript.doFirst {
-+        file('src/.npmrc') << "//registry.npmjs.org/:_authToken=${System.env.NPM_AUTH_TOKEN}"
-+    }
-+}
-```
+If you want to publish npm packages, you need to provide the necessary credentials to `npm publish`. Documentation on how to achieve this can be found [here](https://github.com/palantir/gradle-conjure?tab=readme-ov-file#typescript).


### PR DESCRIPTION
## Before this PR
We assumed the npmrc location and contents, but they changed long ago.

## After this PR
`generateNpmRc` has configuration points to provide a token directly.

