### PR TITLE
ServiceDefinition name field may be omitted

### DIFF
--- a/changelog/@unreleased/pr-1570.v2.yml
+++ b/changelog/@unreleased/pr-1570.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: ServiceDefinition name field may be omitted
+  links:
+  - https://github.com/palantir/conjure/pull/1570

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/services/ServiceDefinition.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/services/ServiceDefinition.java
@@ -37,7 +37,10 @@ public interface ServiceDefinition {
     // TODO(rfink): This is unused. Remove?
     @Deprecated
     @JsonProperty("name")
-    String doNotUseName();
+    @Value.Default
+    default String doNotUseName() {
+        return "";
+    }
 
     @JsonProperty("package")
     ConjurePackage conjurePackage();

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/ConjureDefTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/ConjureDefTest.java
@@ -64,4 +64,11 @@ public class ConjureDefTest {
         ConjureParserUtils.parseConjureDef(
                 ConjureParser.parseAnnotated(new File("src/test/resources/example-external-types.yml")));
     }
+
+    @Test
+    public void namelessService() {
+        ConjureDefinition conjureDefinition = ConjureParserUtils.parseConjureDef(
+                ConjureParser.parseAnnotated(new File("src/test/resources/nameless-test-service.yml")));
+        assertThat(conjureDefinition.getServices()).hasSize(1);
+    }
 }

--- a/conjure-core/src/test/resources/nameless-test-service.yml
+++ b/conjure-core/src/test/resources/nameless-test-service.yml
@@ -1,0 +1,7 @@
+services:
+  NamelessTestService:
+    package: test.api
+
+    endpoints:
+      get:
+        http: GET /get

--- a/conjure.schema.json
+++ b/conjure.schema.json
@@ -390,7 +390,6 @@
         }
       },
       "required": [
-        "name",
         "package",
         "endpoints"
       ]

--- a/docs/spec/conjure_definitions.md
+++ b/docs/spec/conjure_definitions.md
@@ -300,7 +300,6 @@ A service is a collection of endpoints.
 
 Field | Type | Description
 ---|:---:|---
-name | [TypeName][] | **REQUIRED** A human readable name for the service.
 package | `string` | **REQUIRED** The package of the service.
 base&#8209;path | [PathString][] | **REQUIRED** The base path of the service. The path MUST have a leading `/`. The base path is prepended to each endpoint path to construct the final URL. [Path parameters][] are not allowed.
 default&#8209;auth | [AuthDefinition][] | **REQUIRED** The default authentication mechanism for all endpoints in the service.


### PR DESCRIPTION
## Before this PR
`ServiceDefinition.name` has been deprecated for 6 years.

## After this PR
==COMMIT_MSG==
ServiceDefinition name field may be omitted
==COMMIT_MSG==

