### PR TITLE
[HackWeek] Add default values for (select) primitives and enums to the IR compiler

### DIFF
--- a/changelog/@unreleased/pr-1615.v2.yml
+++ b/changelog/@unreleased/pr-1615.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Add default values for primitives and enums to the IR compiler
+  links:
+  - https://github.com/palantir/conjure/pull/1615

--- a/conjure-api/src/main/conjure/conjure-api.yml
+++ b/conjure-api/src/main/conjure/conjure-api.yml
@@ -26,6 +26,17 @@ types:
       Documentation:
         alias: string
 
+      DefaultValue:
+        union:
+          enum: string
+          string: string
+          integer: integer
+          double: double
+          safelong: safelong
+          boolean: boolean
+          uuid: uuid
+          rid: rid
+
       LogSafety:
         docs: >
           Safety with regards to logging based on [safe-logging](https://github.com/palantir/safe-logging) concepts.
@@ -153,6 +164,7 @@ types:
           fieldName: FieldName
           type: Type
           docs: optional<Documentation>
+          default: optional<DefaultValue>
           deprecated: optional<Documentation>
           safety: optional<LogSafety>
       FieldName:

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureParserUtils.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureParserUtils.java
@@ -405,6 +405,9 @@ public final class ConjureParserUtils {
                             .fieldName(parseFieldName(entry.getKey()))
                             .type(entry.getValue().type().visit(new ConjureTypeParserVisitor(typeResolver)))
                             .docs(entry.getValue().docs().map(Documentation::of))
+                            .default_(entry.getValue().default_().map(defaultValue -> entry.getValue()
+                                    .type()
+                                    .visit(new DefaultValueParserVisitor(typeResolver, defaultValue))))
                             .deprecated(entry.getValue().deprecated().map(Documentation::of))
                             .safety(entry.getValue().safety().map(ConjureParserUtils::parseLogSafety))
                             .build();

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/DefaultValueParserVisitor.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/DefaultValueParserVisitor.java
@@ -1,0 +1,171 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.defs;
+
+import com.palantir.conjure.defs.ConjureTypeParserVisitor.ReferenceTypeResolver;
+import com.palantir.conjure.either.Either;
+import com.palantir.conjure.exceptions.ConjureIllegalArgumentException;
+import com.palantir.conjure.java.lib.SafeLong;
+import com.palantir.conjure.parser.types.BaseObjectTypeDefinition;
+import com.palantir.conjure.parser.types.ConjureTypeVisitor;
+import com.palantir.conjure.parser.types.TypeDefinitionVisitor;
+import com.palantir.conjure.parser.types.builtin.AnyType;
+import com.palantir.conjure.parser.types.builtin.BinaryType;
+import com.palantir.conjure.parser.types.builtin.DateTimeType;
+import com.palantir.conjure.parser.types.collect.ListType;
+import com.palantir.conjure.parser.types.collect.MapType;
+import com.palantir.conjure.parser.types.collect.OptionalType;
+import com.palantir.conjure.parser.types.collect.SetType;
+import com.palantir.conjure.parser.types.complex.EnumTypeDefinition;
+import com.palantir.conjure.parser.types.complex.EnumValueDefinition;
+import com.palantir.conjure.parser.types.complex.ObjectTypeDefinition;
+import com.palantir.conjure.parser.types.complex.UnionTypeDefinition;
+import com.palantir.conjure.parser.types.names.TypeName;
+import com.palantir.conjure.parser.types.primitive.PrimitiveType;
+import com.palantir.conjure.parser.types.reference.AliasTypeDefinition;
+import com.palantir.conjure.parser.types.reference.ForeignReferenceType;
+import com.palantir.conjure.parser.types.reference.LocalReferenceType;
+import com.palantir.conjure.spec.DefaultValue;
+import com.palantir.ri.ResourceIdentifier;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public final class DefaultValueParserVisitor implements ConjureTypeVisitor<DefaultValue> {
+    private static final TypeDefinitionExtractor DEFINITION_EXTRACTOR = new TypeDefinitionExtractor();
+    private final ReferenceTypeResolver typeResolver;
+    private final String value;
+
+    public DefaultValueParserVisitor(ReferenceTypeResolver typeResolver, String value) {
+        this.typeResolver = typeResolver;
+        this.value = value;
+    }
+
+    @Override
+    public DefaultValue visitAny(AnyType _type) {
+        throw new ConjureIllegalArgumentException("Fields of type 'any' do not support default values");
+    }
+
+    @Override
+    public DefaultValue visitList(ListType _type) {
+        throw new ConjureIllegalArgumentException("Fields of type 'list' do not support default values");
+    }
+
+    @Override
+    public DefaultValue visitMap(MapType _type) {
+        throw new ConjureIllegalArgumentException("Fields of type 'map' do not support default values");
+    }
+
+    @Override
+    public DefaultValue visitOptional(OptionalType _type) {
+        throw new ConjureIllegalArgumentException("Fields of type 'optional' do not support default values");
+    }
+
+    @Override
+    public DefaultValue visitPrimitive(PrimitiveType type) {
+        switch (type) {
+            case STRING:
+                return DefaultValue.string(value);
+            case RID:
+                return DefaultValue.rid(ResourceIdentifier.valueOf(value));
+            case UUID:
+                return DefaultValue.uuid(UUID.fromString(value));
+            case INTEGER:
+                return DefaultValue.integer(Integer.parseInt(value));
+            case SAFELONG:
+                return DefaultValue.safelong(SafeLong.valueOf(value));
+            case DOUBLE:
+                return DefaultValue.double_(Double.parseDouble(value));
+            case BOOLEAN:
+                return DefaultValue.boolean_(
+                        value.equalsIgnoreCase("true") || value.equalsIgnoreCase("yes") || value.equalsIgnoreCase("1"));
+            default:
+                throw new ConjureIllegalArgumentException(
+                        String.format("Fields of type '%s' do not support default values", type.name()));
+        }
+    }
+
+    @Override
+    public DefaultValue visitLocalReference(LocalReferenceType type) {
+        return parseEnumValue(type.type(), typeResolver.extractDefinition(type));
+    }
+
+    @Override
+    public DefaultValue visitForeignReference(ForeignReferenceType type) {
+        return parseEnumValue(type.type(), typeResolver.extractDefinition(type));
+    }
+
+    @Override
+    public DefaultValue visitSet(SetType _type) {
+        throw new ConjureIllegalArgumentException("Fields of type 'set' do not support default values");
+    }
+
+    @Override
+    public DefaultValue visitBinary(BinaryType _type) {
+        throw new ConjureIllegalArgumentException("Fields of type 'binary' do not support default values");
+    }
+
+    @Override
+    public DefaultValue visitDateTime(DateTimeType _type) {
+        throw new ConjureIllegalArgumentException("Fields of type 'datetime' do not support default values");
+    }
+
+    private DefaultValue parseEnumValue(TypeName typeName, Optional<BaseObjectTypeDefinition> typeDefinition) {
+        return typeDefinition
+                .flatMap(maybeDef -> maybeDef.visit(DEFINITION_EXTRACTOR)
+                        .map(def -> def.fold(aliasDef -> aliasDef.alias().visit(this), enumDef -> {
+                            Set<String> legalValues = enumDef.values().stream()
+                                    .map(EnumValueDefinition::value)
+                                    .collect(Collectors.toUnmodifiableSet());
+
+                            if (!legalValues.contains(value)) {
+                                throw new ConjureIllegalArgumentException(String.format(
+                                        "'%s' is not a legal default value for type '%s'", value, typeName.name()));
+                            }
+                            return DefaultValue.enum_(value);
+                        })))
+                .orElseThrow(() -> new ConjureIllegalArgumentException(String.format(
+                        "Only fields of primitive or enum type may have default values, not '%s'", typeName.name())));
+    }
+
+    private static final class TypeDefinitionExtractor
+            implements TypeDefinitionVisitor<Optional<Either<AliasTypeDefinition, EnumTypeDefinition>>> {
+
+        private TypeDefinitionExtractor() {}
+
+        @Override
+        public Optional<Either<AliasTypeDefinition, EnumTypeDefinition>> visit(AliasTypeDefinition def) {
+            return Optional.of(Either.left(def));
+        }
+
+        @Override
+        public Optional<Either<AliasTypeDefinition, EnumTypeDefinition>> visit(EnumTypeDefinition def) {
+            return Optional.of(Either.right(def));
+        }
+
+        @Override
+        public Optional<Either<AliasTypeDefinition, EnumTypeDefinition>> visit(ObjectTypeDefinition _def) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<Either<AliasTypeDefinition, EnumTypeDefinition>> visit(UnionTypeDefinition _def) {
+            return Optional.empty();
+        }
+    }
+}

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/types/complex/FieldDefinition.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/types/complex/FieldDefinition.java
@@ -16,6 +16,7 @@
 
 package com.palantir.conjure.parser.types.complex;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
@@ -37,6 +38,9 @@ public interface FieldDefinition {
     ConjureType type();
 
     Optional<String> docs();
+
+    @JsonProperty("default")
+    Optional<String> default_();
 
     Optional<String> deprecated();
 

--- a/conjure-core/src/test/resources/example-bad-defaults-enum-value.yml
+++ b/conjure-core/src/test/resources/example-bad-defaults-enum-value.yml
@@ -1,0 +1,14 @@
+types:
+  definitions:
+    default-package: com.palantir.defaults
+    objects:
+      EnumType:
+        values:
+          - ONE
+          - TWO
+          - THREE
+      BadEnumObject:
+        fields:
+          enumField:
+            type: EnumType
+            default: FOUR

--- a/conjure-core/src/test/resources/example-bad-defaults-illegal-type.yml
+++ b/conjure-core/src/test/resources/example-bad-defaults-illegal-type.yml
@@ -1,0 +1,19 @@
+types:
+  definitions:
+    default-package: com.palantir.defaults
+    objects:
+      EnumType:
+        values:
+          - ONE
+          - TWO
+          - THREE
+      EnumObject:
+        fields:
+          enumField:
+            type: EnumType
+            default: TWO
+      EnumObjectTwo:
+        fields:
+          enumField:
+            type: EnumObject
+            default: ONE

--- a/conjure-core/src/test/resources/example-defaults.yml
+++ b/conjure-core/src/test/resources/example-defaults.yml
@@ -1,0 +1,66 @@
+types:
+  definitions:
+    default-package: com.palantir.defaults
+    objects:
+      EnumType:
+        values:
+          - ONE
+          - TWO
+          - THREE
+      OtherEnumType:
+        alias: EnumType
+      EnumObject:
+        fields:
+          enumField:
+            type: EnumType
+            default: TWO
+      OtherEnumObject:
+        fields:
+          enumField:
+            type: OtherEnumType
+            default: THREE
+#      BadEnumObject:
+#        fields:
+#          enumField:
+#            type: EnumType
+#            default: FOUR
+#      BadEnumObjectTwo:
+#        fields:
+#          enumField:
+#            type: EnumObject
+#            default: ONE
+      RidObject:
+        fields:
+          ridField:
+            type: rid
+            default: ri.foundry.fake.dataset.fake
+      UuidObject:
+        fields:
+          uuidField:
+            type: uuid
+            default: cc92c9f3-4f16-44c5-b14d-c3cc54f56315
+      StringObject:
+        fields:
+          stringField:
+            type: string
+            default: default
+      SafeLongObject:
+        fields:
+          safeLongField:
+            type: safelong
+            default: 9007199254740990
+      IntegerObject:
+        fields:
+          intField:
+            type: integer
+            default: 0
+      DoubleObject:
+        fields:
+          doubleField:
+            type: double
+            default: 0.5
+      BooleanObject:
+        fields:
+          booleanField:
+            type: boolean
+            default: false


### PR DESCRIPTION
## Before this PR
Services using Conjure that wish to remain backwards-compatible while expanding their storage types must declare all new types as `Optional`s in order to avoid breaking Conjure's deserialization. This requires defaults to be declared in the implementation layer rather than in the API layer, in addition to creating a large number of useless box objects that bloat memory, and confusing the API spec with optional objects that are not actually optional. I personally have encountered bugs where a value was accidentally omitted from a "for backwards-compatibility only" in a storage type, causing developer hours to be wasted on something that should have been caught by the type system.

## After this PR
[FieldDefinition](https://palantir.github.io/conjure/#/docs/spec/conjure_definitions?id=fielddefinition)s in YAML now support a `default` parameter which accepts a value to supplied when null or empty values of this field are deserialized instead of throwing an error. Currently all primitive types (barring bearertokens and `ANY`) and enum values are supported. More complex types would work too, but the demand is small and I want to constrain the scope of this project.

==COMMIT_MSG==
Add default values for primitives and enums to the IR compiler
==COMMIT_MSG==