### PR TITLE
Mention maximum precision of datetimes

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -30,7 +30,7 @@ Users may define the following kinds of named types. These can be referenced by 
   - `bearertoken` - a string [Json Web Token (JWT)](https://jwt.io/)
   - `binary` - a sequence of binary.
   - `boolean` - `true` or `false`
-  - `datetime` - an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) value e.g. `2018-07-25T10:20:32+01:00`
+  - `datetime` - an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) value (up to nanosecond precision) e.g. `2018-07-25T10:20:32.012+01:00`
   - `double` - a floating point number specified by [IEEE 754](https://ieeexplore.ieee.org/document/4610935/), which includes NaN, +/-Infinity and signed zero.
   - `integer` - a signed 32-bit integer value ranging from -2<sup>31</sup> to 2<sup>31</sup> - 1.
   - `rid` - a [Resource Identifier](https://github.com/palantir/resource-identifier), e.g. `ri.recipes.main.ingredient.1234`


### PR DESCRIPTION
I could not find documentation which stated the allowed precision of datetimes. The docs link to the [wiki article for iso8601](https://en.wikipedia.org/wiki/ISO_8601#Times), but the standard doesn't state a limit to the precision:

> There is no limit on the number of decimal places for the decimal fraction. However, the number of decimal places needs to be agreed to by the communicating parties. For example, in Microsoft SQL Server, the precision of a decimal fraction is 3 for a DATETIME, i.e., "yyyy-mm-ddThh:mm:ss[.mmm]".

However if you look at the [conjure master test cases](https://github.com/palantir/conjure-verification/blob/0ab21871e840defca92cc6d3ba375e0220651d93/master-test-cases.yml#L43-L56), an example with 9 decimal digits is in the positive test set, and one with 10 digits in the negative set:

```yaml
  - type: DateTimeExample
    positive:
        - '{"value":"2017-01-02T03:04:05Z"}'
        - '{"value":"2017-01-02T03:04:05.000Z"}'
        - '{"value":"2017-01-02T03:04:05.000000Z"}'
        - '{"value":"2017-01-02T03:04:05.000000000Z"}'  # 9 digits
        - '{"value":"2017-01-02T04:04:05.000000000+01:00"}'
        - '{"value":"2017-01-02T05:04:05.000000000+02:00"}'
    negative:
        - '{"value":"4/3/2018"}'
        - '{"value":"1523040070"}'
        - '{"value":1523040070}'
        - '{"value":"2017-01-02T03:04:05.0000000000Z"}'  # 10 digits
        - '{"value":"2017-01-02T04:04:05.000000000+01:00[Europe/Berlin]"}'
```