### PR TITLE
[Feature] Allow ConjureTypes to be the 'base-type' on an External Import

### DIFF
--- a/changelog/@unreleased/pr-1661.v2.yml
+++ b/changelog/@unreleased/pr-1661.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: '[FR] Allow ConjureTypes to be the ''base-type'' on an External Import'
+  links:
+  - https://github.com/palantir/conjure/pull/1661

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureParserUtils.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureParserUtils.java
@@ -193,15 +193,20 @@ public final class ConjureParserUtils {
         return Type.primitive(PrimitiveType.valueOf(primitiveType.name()));
     }
 
-    static Type parseExternalType(ExternalTypeDefinition externalType, String conjurePackage, String typeName) {
+    static Type parseExternalType(
+            ExternalTypeDefinition externalType,
+            ReferenceTypeResolver nameResolver,
+            String conjurePackage,
+            String typeName) {
         if (isBearerToken(externalType) && externalType.safety().isPresent()) {
             throw new ConjureRuntimeException(
                     "Cannot mark safety of external import with base type BearerToken. BearerToken assumes Do Not"
                             + " Log.");
         }
+
         return Type.external(ExternalReference.builder()
                 .externalReference(TypeName.of(typeName, conjurePackage))
-                .fallback(ConjureParserUtils.parsePrimitiveType(externalType.baseType()))
+                .fallback(externalType.baseType().visit(new ConjureTypeParserVisitor(nameResolver)))
                 .safety(externalType.safety().map(ConjureParserUtils::parseLogSafety))
                 .build());
     }

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureTypeParserVisitor.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureTypeParserVisitor.java
@@ -66,7 +66,7 @@ public final class ConjureTypeParserVisitor implements ConjureTypeVisitor<Type> 
 
         @Override
         public Type resolve(LocalReferenceType reference) {
-            return resolveFromTypeName(reference.type(), types);
+            return resolveFromTypeName(reference.type(), this, types);
         }
 
         @Override
@@ -77,11 +77,13 @@ public final class ConjureTypeParserVisitor implements ConjureTypeVisitor<Type> 
             Preconditions.checkNotNull(
                     externalFile, "File not found for namespace: %s @ %s", reference.namespace(), namespaceFile);
             return resolveFromTypeName(
-                    reference.type(), externalFile.conjureSourceFile().types());
+                    reference.type(), this, externalFile.conjureSourceFile().types());
         }
 
         private static Type resolveFromTypeName(
-                com.palantir.conjure.parser.types.names.TypeName name, TypesDefinition types) {
+                com.palantir.conjure.parser.types.names.TypeName name,
+                ReferenceTypeResolver nameResolver,
+                TypesDefinition types) {
             Optional<String> defaultPackage =
                     types.definitions().defaultConjurePackage().map(ConjureParserUtils::parseConjurePackage);
             BaseObjectTypeDefinition maybeDirectDef =
@@ -98,7 +100,7 @@ public final class ConjureTypeParserVisitor implements ConjureTypeVisitor<Type> 
                 conjurePackage = externalPath.substring(0, lastIndex);
                 String typeName = externalPath.substring(lastIndex + 1);
 
-                return ConjureParserUtils.parseExternalType(maybeExternalDef, conjurePackage, typeName);
+                return ConjureParserUtils.parseExternalType(maybeExternalDef, nameResolver, conjurePackage, typeName);
             } else {
                 // Conjure-defined object
                 conjurePackage =

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/types/reference/ExternalTypeDefinition.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/types/reference/ExternalTypeDefinition.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.palantir.conjure.defs.ConjureImmutablesStyle;
 import com.palantir.conjure.parser.LogSafetyDefinition;
+import com.palantir.conjure.parser.types.ConjureType;
 import com.palantir.conjure.parser.types.ExternalImportDefinition;
 import com.palantir.conjure.parser.types.primitive.PrimitiveType;
 import java.util.Optional;
@@ -34,7 +35,7 @@ public interface ExternalTypeDefinition {
 
     @JsonProperty("base-type")
     @Value.Default
-    default PrimitiveType baseType() {
+    default ConjureType baseType() {
         return PrimitiveType.ANY;
     }
 

--- a/conjure-core/src/test/java/com/palantir/conjure/parser/ConjureParserTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/parser/ConjureParserTest.java
@@ -26,6 +26,7 @@ import com.palantir.conjure.defs.ConjureArgs;
 import com.palantir.conjure.defs.SafetyDeclarationRequirements;
 import com.palantir.conjure.exceptions.ConjureRuntimeException;
 import com.palantir.conjure.parser.types.TypeDefinitionVisitor;
+import com.palantir.conjure.parser.types.builtin.AnyType;
 import com.palantir.conjure.parser.types.complex.EnumTypeDefinition;
 import com.palantir.conjure.parser.types.complex.EnumValueDefinition;
 import com.palantir.conjure.parser.types.complex.ObjectTypeDefinition;
@@ -33,7 +34,6 @@ import com.palantir.conjure.parser.types.complex.UnionTypeDefinition;
 import com.palantir.conjure.parser.types.names.FieldName;
 import com.palantir.conjure.parser.types.names.Namespace;
 import com.palantir.conjure.parser.types.names.TypeName;
-import com.palantir.conjure.parser.types.primitive.PrimitiveType;
 import com.palantir.conjure.parser.types.reference.AliasTypeDefinition;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.io.File;
@@ -100,7 +100,7 @@ public class ConjureParserTest {
                         .imports()
                         .get(TypeName.of("ExampleAnyImport"))
                         .baseType())
-                .isEqualTo(PrimitiveType.fromString("any"));
+                .isEqualTo(AnyType.of());
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
According to the [definition spec for `ExternalTypes`](https://github.com/palantir/conjure/blob/master/docs/spec/conjure_definitions.md#externaltypedefinition), it is a valid definition to allow for any [`ConjureType` which includes `ContainerType`](https://github.com/palantir/conjure/blob/master/docs/spec/conjure_definitions.md#conjuretype). However, when I wrote the following definition:

```yaml
types:
  imports:
    Flags:
      base-type: list<string>
      external:
        java: com.palantir.Flags
```

It errored out with the following:

```
Cannot construct instance of `com.palantir.conjure.parser.types.primitive.PrimitiveType`, problem: TypeNames must be a primitive type [datetime, boolean, string, double, bearertoken, binary, safelong, integer, rid, any, uuid] or match pattern ^[A-Z][a-z0-9]+([A-Z][a-z0-9]+)*$: list<string>
  @ types -> imports -> Flags -> base-type
TypeNames must be a primitive type [datetime, boolean, string, double, bearertoken, binary, safelong, integer, rid, any, uuid] or match pattern ^[A-Z][a-z0-9]+([A-Z][a-z0-9]+)*$: list<string>
```

## After this PR
Changes the `base-type` deserialization object to allow for all valid `ConjureTypes`. This addresses a concern where you want to optimize the serialization of a type in Java, but you are also adhering to the wire spec and thus have a valid conjure compliant serialization i.e. it is safe to convey that type to other generators instead of defaulting to `any`.

## Possible downsides?
Spec is one thing, observed behavior is another. I think because this is a strict expansion of the optionality this _might_ be safe. As in it should not break anyone because every existing instance is a `PrimitiveType` which is a subset of `ConjureType`. However, what this now means is that the following complex setup is valid:

```yaml
types:
  imports:
    Flags:
      base-type: list< ComplexFlags >
      external:
        java: com.palantir.Flags
        
  definitions:
    default-package: com.palantir
    objects:
      ComplexFlags:
        fields:
          field1: string
          field2: string
```

I'm not sure if this is an issue. I need to consider it more. My initial thought is that this is fine, because the intent of `base-type` is that it be a type that every language can represent. Which is tautologically true given the nature of Conjure. And `ConjureType` is strictly either primitive, collection, or typename and specifically cannot reference another `ExternalType`.

I also did some quick searching for usages and there is only one place that relies on the return type of `baseType()` so this should not be that disruptive from that perspective.

## ToDo

- [ ] Compare the generated IR with a locally published version
- [ ] Consider what consumers of this IR may or may not be expecting