### PR TITLE
Support specifying errors on endpoints

### DIFF
--- a/changelog/@unreleased/pr-1670.v2.yml
+++ b/changelog/@unreleased/pr-1670.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Support specifying errors on endpoints
+  links:
+  - https://github.com/palantir/conjure/pull/1670

--- a/conjure-api/src/main/conjure/conjure-api.yml
+++ b/conjure-api/src/main/conjure/conjure-api.yml
@@ -173,6 +173,7 @@ types:
           auth: optional<AuthType>
           args: list<ArgumentDefinition>
           returns: optional<Type>
+          errors: list<EndpointError>
           docs: optional<Documentation>
           deprecated: optional<Documentation>
           markers: list<Type>
@@ -180,6 +181,10 @@ types:
       EndpointName:
         alias: string
         docs: Should be in lowerCamelCase.
+      EndpointError:
+        fields:
+          errorName: TypeName
+          docs: optional<Documentation>
       HttpMethod:
         values:
           - GET

--- a/conjure-api/src/main/conjure/conjure-api.yml
+++ b/conjure-api/src/main/conjure/conjure-api.yml
@@ -183,7 +183,7 @@ types:
         docs: Should be in lowerCamelCase.
       EndpointError:
         fields:
-          errorName: TypeName
+          error: TypeName
           docs: optional<Documentation>
       HttpMethod:
         values:

--- a/conjure-api/src/main/conjure/conjure-api.yml
+++ b/conjure-api/src/main/conjure/conjure-api.yml
@@ -183,7 +183,12 @@ types:
         docs: Should be in lowerCamelCase.
       EndpointError:
         fields:
-          error: TypeName
+          name:
+            type: string
+            docs: A reference to an error definition.
+          package:
+            type: string
+            docs: A period-delimited string of package names.
           namespace: ErrorNamespace
           docs: optional<Documentation>
       HttpMethod:

--- a/conjure-api/src/main/conjure/conjure-api.yml
+++ b/conjure-api/src/main/conjure/conjure-api.yml
@@ -184,6 +184,7 @@ types:
       EndpointError:
         fields:
           error: TypeName
+          namespace: ErrorNamespace
           docs: optional<Documentation>
       HttpMethod:
         values:

--- a/conjure-api/src/main/conjure/conjure-api.yml
+++ b/conjure-api/src/main/conjure/conjure-api.yml
@@ -181,7 +181,7 @@ types:
       EndpointName:
         alias: string
         docs: Should be in lowerCamelCase.
-      EndpointError:
+      ErrorTypeName:
         fields:
           name:
             type: string
@@ -190,6 +190,9 @@ types:
             type: string
             docs: A period-delimited string of package names.
           namespace: ErrorNamespace
+      EndpointError:
+        fields:
+          error: ErrorTypeName
           docs: optional<Documentation>
       HttpMethod:
         values:

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureParserUtils.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureParserUtils.java
@@ -465,7 +465,7 @@ public final class ConjureParserUtils {
                 .returns(def.returns().map(t -> t.visit(new ConjureTypeParserVisitor(typeResolver))))
                 .errors(def.errors().stream()
                         .map(endpointError -> EndpointError.builder()
-                                .errorName(endpointErrorResolver.resolve(endpointError.errorName()))
+                                .error(endpointErrorResolver.resolve(endpointError.error()))
                                 .docs(endpointError.docs().map(Documentation::of))
                                 .build())
                         .toList())

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureParserUtils.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureParserUtils.java
@@ -469,7 +469,8 @@ public final class ConjureParserUtils {
                             ErrorResolutionResult errorResolutionResult =
                                     endpointErrorResolver.resolve(endpointError.error());
                             return EndpointError.builder()
-                                    .error(errorResolutionResult.typeName())
+                                    .name(errorResolutionResult.errorName())
+                                    .package_(errorResolutionResult.package_())
                                     .namespace(errorResolutionResult.namespace())
                                     .docs(endpointError.docs().map(Documentation::of))
                                     .build();

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureParserUtils.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureParserUtils.java
@@ -18,6 +18,7 @@ package com.palantir.conjure.defs;
 
 import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.defs.ConjureTypeParserVisitor.ReferenceTypeResolver;
+import com.palantir.conjure.defs.EndpointErrorResolver.ErrorResolutionResult;
 import com.palantir.conjure.defs.validator.ConjureDefinitionValidator;
 import com.palantir.conjure.defs.validator.EndpointDefinitionValidator;
 import com.palantir.conjure.defs.validator.EnumDefinitionValidator;
@@ -464,10 +465,15 @@ public final class ConjureParserUtils {
                 .markers(parseMarkers(def.markers(), typeResolver))
                 .returns(def.returns().map(t -> t.visit(new ConjureTypeParserVisitor(typeResolver))))
                 .errors(def.errors().stream()
-                        .map(endpointError -> EndpointError.builder()
-                                .error(endpointErrorResolver.resolve(endpointError.error()))
-                                .docs(endpointError.docs().map(Documentation::of))
-                                .build())
+                        .map(endpointError -> {
+                            ErrorResolutionResult errorResolutionResult =
+                                    endpointErrorResolver.resolve(endpointError.error());
+                            return EndpointError.builder()
+                                    .error(errorResolutionResult.typeName())
+                                    .namespace(errorResolutionResult.namespace())
+                                    .docs(endpointError.docs().map(Documentation::of))
+                                    .build();
+                        })
                         .toList())
                 .docs(def.docs().map(Documentation::of))
                 .deprecated(def.deprecated().map(Documentation::of))

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureParserUtils.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/ConjureParserUtils.java
@@ -18,7 +18,6 @@ package com.palantir.conjure.defs;
 
 import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.defs.ConjureTypeParserVisitor.ReferenceTypeResolver;
-import com.palantir.conjure.defs.EndpointErrorResolver.ErrorResolutionResult;
 import com.palantir.conjure.defs.validator.ConjureDefinitionValidator;
 import com.palantir.conjure.defs.validator.EndpointDefinitionValidator;
 import com.palantir.conjure.defs.validator.EnumDefinitionValidator;
@@ -465,16 +464,10 @@ public final class ConjureParserUtils {
                 .markers(parseMarkers(def.markers(), typeResolver))
                 .returns(def.returns().map(t -> t.visit(new ConjureTypeParserVisitor(typeResolver))))
                 .errors(def.errors().stream()
-                        .map(endpointError -> {
-                            ErrorResolutionResult errorResolutionResult =
-                                    endpointErrorResolver.resolve(endpointError.error());
-                            return EndpointError.builder()
-                                    .name(errorResolutionResult.errorName())
-                                    .package_(errorResolutionResult.package_())
-                                    .namespace(errorResolutionResult.namespace())
-                                    .docs(endpointError.docs().map(Documentation::of))
-                                    .build();
-                        })
+                        .map(endpointError -> EndpointError.builder()
+                                .error(endpointErrorResolver.resolve(endpointError.error()))
+                                .docs(endpointError.docs().map(Documentation::of))
+                                .build())
                         .toList())
                 .docs(def.docs().map(Documentation::of))
                 .deprecated(def.deprecated().map(Documentation::of))

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/EndpointErrorResolver.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/EndpointErrorResolver.java
@@ -1,0 +1,152 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.defs;
+
+import com.google.common.base.Preconditions;
+import com.palantir.conjure.parser.AnnotatedConjureSourceFile;
+import com.palantir.conjure.parser.types.BaseObjectTypeDefinition;
+import com.palantir.conjure.parser.types.ConjureType;
+import com.palantir.conjure.parser.types.ConjureTypeVisitor;
+import com.palantir.conjure.parser.types.builtin.AnyType;
+import com.palantir.conjure.parser.types.builtin.BinaryType;
+import com.palantir.conjure.parser.types.builtin.DateTimeType;
+import com.palantir.conjure.parser.types.collect.ListType;
+import com.palantir.conjure.parser.types.collect.MapType;
+import com.palantir.conjure.parser.types.collect.OptionalType;
+import com.palantir.conjure.parser.types.collect.SetType;
+import com.palantir.conjure.parser.types.complex.ErrorTypeDefinition;
+import com.palantir.conjure.parser.types.names.ConjurePackage;
+import com.palantir.conjure.parser.types.names.Namespace;
+import com.palantir.conjure.parser.types.names.TypeName;
+import com.palantir.conjure.parser.types.primitive.PrimitiveType;
+import com.palantir.conjure.parser.types.reference.ForeignReferenceType;
+import com.palantir.conjure.parser.types.reference.LocalReferenceType;
+import com.palantir.logsafe.SafeArg;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Endpoint error definitions are either references to errors defined in the same file as the endpoint definition, or in
+ * imported Conjure files. This class resolved the reference to the error type populating the package name if necessary.
+ */
+public final class EndpointErrorResolver implements ConjureTypeVisitor<com.palantir.conjure.spec.TypeName> {
+    private static final String UNSUPPORTED_TYPE_MESSAGE =
+            "Unsupported endpoint error type. Endpoint errors must be references to a Conjure-defined error type";
+
+    private final Map<TypeName, ErrorTypeDefinition> parsedErrors;
+    private final Optional<ConjurePackage> defaultConjurePackage;
+    private final Map<Namespace, String> importProviders;
+    private final Map<String, AnnotatedConjureSourceFile> externalTypes;
+
+    public EndpointErrorResolver(
+            Map<TypeName, ErrorTypeDefinition> parsedErrors,
+            Optional<ConjurePackage> defaultConjurePackage,
+            Map<Namespace, String> importProviders,
+            Map<String, AnnotatedConjureSourceFile> externalTypes) {
+        this.parsedErrors = parsedErrors;
+        this.defaultConjurePackage = defaultConjurePackage;
+        this.importProviders = importProviders;
+        this.externalTypes = externalTypes;
+    }
+
+    public com.palantir.conjure.spec.TypeName resolve(ConjureType conjureType) {
+        return conjureType.visit(this);
+    }
+
+    private com.palantir.conjure.spec.TypeName resolveReferenceType(LocalReferenceType localReferenceType) {
+        return resolveInternal(localReferenceType.type(), parsedErrors, defaultConjurePackage);
+    }
+
+    private com.palantir.conjure.spec.TypeName resolveReferenceType(ForeignReferenceType foreignReferenceType) {
+        String namespaceFile = importProviders.get(foreignReferenceType.namespace());
+        Preconditions.checkNotNull(
+                namespaceFile, "Import not found for namespace: %s", foreignReferenceType.namespace());
+        AnnotatedConjureSourceFile externalFile = externalTypes.get(namespaceFile);
+        Preconditions.checkNotNull(
+                externalFile, "File not found for namespace: %s @ %s", foreignReferenceType.namespace(), namespaceFile);
+        return resolveInternal(
+                foreignReferenceType.type(),
+                externalFile.conjureSourceFile().types().definitions().errors(),
+                externalFile.conjureSourceFile().types().definitions().defaultConjurePackage());
+    }
+
+    private static com.palantir.conjure.spec.TypeName resolveInternal(
+            TypeName name,
+            Map<TypeName, ErrorTypeDefinition> parsedErrorDefinitions,
+            Optional<ConjurePackage> defaultConjurePackage) {
+        BaseObjectTypeDefinition errorDefinition = parsedErrorDefinitions.get(name);
+        if (errorDefinition == null) {
+            throw new SafeIllegalArgumentException("Unknown error", SafeArg.of("error", name.name()));
+        }
+        return com.palantir.conjure.spec.TypeName.of(
+                name.name(),
+                ConjureParserUtils.parsePackageOrElseThrow(
+                        errorDefinition.conjurePackage(),
+                        defaultConjurePackage.map(ConjureParserUtils::parseConjurePackage)));
+    }
+
+    @Override
+    public com.palantir.conjure.spec.TypeName visitAny(AnyType type) {
+        throw new SafeIllegalArgumentException(UNSUPPORTED_TYPE_MESSAGE, SafeArg.of("type", type));
+    }
+
+    @Override
+    public com.palantir.conjure.spec.TypeName visitList(ListType type) {
+        throw new SafeIllegalArgumentException(UNSUPPORTED_TYPE_MESSAGE, SafeArg.of("type", type));
+    }
+
+    @Override
+    public com.palantir.conjure.spec.TypeName visitMap(MapType type) {
+        throw new SafeIllegalArgumentException(UNSUPPORTED_TYPE_MESSAGE, SafeArg.of("type", type));
+    }
+
+    @Override
+    public com.palantir.conjure.spec.TypeName visitOptional(OptionalType type) {
+        throw new SafeIllegalArgumentException(UNSUPPORTED_TYPE_MESSAGE, SafeArg.of("type", type));
+    }
+
+    @Override
+    public com.palantir.conjure.spec.TypeName visitPrimitive(PrimitiveType type) {
+        throw new SafeIllegalArgumentException(UNSUPPORTED_TYPE_MESSAGE, SafeArg.of("type", type));
+    }
+
+    @Override
+    public com.palantir.conjure.spec.TypeName visitLocalReference(LocalReferenceType type) {
+        return resolveReferenceType(type);
+    }
+
+    @Override
+    public com.palantir.conjure.spec.TypeName visitForeignReference(ForeignReferenceType type) {
+        return resolveReferenceType(type);
+    }
+
+    @Override
+    public com.palantir.conjure.spec.TypeName visitSet(SetType type) {
+        throw new SafeIllegalArgumentException(UNSUPPORTED_TYPE_MESSAGE, SafeArg.of("type", type));
+    }
+
+    @Override
+    public com.palantir.conjure.spec.TypeName visitBinary(BinaryType type) {
+        throw new SafeIllegalArgumentException(UNSUPPORTED_TYPE_MESSAGE, SafeArg.of("type", type));
+    }
+
+    @Override
+    public com.palantir.conjure.spec.TypeName visitDateTime(DateTimeType type) {
+        throw new SafeIllegalArgumentException(UNSUPPORTED_TYPE_MESSAGE, SafeArg.of("type", type));
+    }
+}

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/EndpointErrorResolver.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/EndpointErrorResolver.java
@@ -42,7 +42,8 @@ import java.util.Optional;
 
 /**
  * Endpoint error definitions are either references to errors defined in the same file as the endpoint definition, or in
- * imported Conjure files. This class resolved the reference to the error type populating the package name if necessary.
+ * imported Conjure files. This class creates a {@link com.palantir.conjure.spec.TypeName} object from a
+ * {@link com.palantir.conjure.parser.types.reference.ReferenceType} to a Conjure defined error definition.
  */
 public final class EndpointErrorResolver implements ConjureTypeVisitor<com.palantir.conjure.spec.TypeName> {
     private static final String UNSUPPORTED_TYPE_MESSAGE =

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/EndpointErrorResolver.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/EndpointErrorResolver.java
@@ -66,7 +66,7 @@ final class EndpointErrorResolver implements ConjureTypeVisitor<ErrorResolutionR
     }
 
     record ErrorResolutionResult(
-            com.palantir.conjure.spec.TypeName typeName, com.palantir.conjure.spec.ErrorNamespace namespace) {}
+            String errorName, String package_, com.palantir.conjure.spec.ErrorNamespace namespace) {}
 
     ErrorResolutionResult resolve(ConjureType conjureType) {
         return conjureType.visit(this);
@@ -98,11 +98,10 @@ final class EndpointErrorResolver implements ConjureTypeVisitor<ErrorResolutionR
             throw new SafeIllegalArgumentException("Unknown error", SafeArg.of("error", name.name()));
         }
         return new ErrorResolutionResult(
-                com.palantir.conjure.spec.TypeName.of(
-                        name.name(),
-                        ConjureParserUtils.parsePackageOrElseThrow(
-                                errorDefinition.conjurePackage(),
-                                defaultConjurePackage.map(ConjureParserUtils::parseConjurePackage))),
+                name.name(),
+                ConjureParserUtils.parsePackageOrElseThrow(
+                        errorDefinition.conjurePackage(),
+                        defaultConjurePackage.map(ConjureParserUtils::parseConjurePackage)),
                 com.palantir.conjure.spec.ErrorNamespace.of(
                         errorDefinition.namespace().name()));
     }

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/EndpointDefinitionValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/EndpointDefinitionValidator.java
@@ -477,13 +477,16 @@ public enum EndpointDefinitionValidator implements ConjureContextualValidator<En
     private static final class NoDuplicateEndpointErrorsValidation implements ConjureValidator<EndpointDefinition> {
         @Override
         public void validate(EndpointDefinition definition) {
-            Set<String> endpointErrorNames = new HashSet<>();
+            Set<String> endpointErrorNameAndNamespaces = new HashSet<>();
             for (EndpointError endpointErrorDef : definition.getErrors()) {
                 String errorName = endpointErrorDef.getError().getName();
+                String errorNamespace = endpointErrorDef.getNamespace().get();
+                String errorUniqueId = errorName + ":" + errorNamespace;
                 Preconditions.checkArgument(
-                        endpointErrorNames.add(errorName),
-                        "Error '%s' is declared multiple times in endpoint '%s'",
+                        endpointErrorNameAndNamespaces.add(errorUniqueId),
+                        "Error '%s' with namespace '%s' is declared multiple times in endpoint '%s'",
                         errorName,
+                        errorNamespace,
                         describe(definition));
             }
         }

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/EndpointDefinitionValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/EndpointDefinitionValidator.java
@@ -479,7 +479,7 @@ public enum EndpointDefinitionValidator implements ConjureContextualValidator<En
         public void validate(EndpointDefinition definition) {
             Set<String> endpointErrorNameAndNamespaces = new HashSet<>();
             for (EndpointError endpointErrorDef : definition.getErrors()) {
-                String errorName = endpointErrorDef.getError().getName();
+                String errorName = endpointErrorDef.getName();
                 String errorNamespace = endpointErrorDef.getNamespace().get();
                 String errorUniqueId = errorName + ":" + errorNamespace;
                 Preconditions.checkArgument(

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/EndpointDefinitionValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/EndpointDefinitionValidator.java
@@ -26,6 +26,7 @@ import com.palantir.conjure.spec.ArgumentDefinition;
 import com.palantir.conjure.spec.ArgumentName;
 import com.palantir.conjure.spec.EndpointDefinition;
 import com.palantir.conjure.spec.EndpointError;
+import com.palantir.conjure.spec.ErrorTypeName;
 import com.palantir.conjure.spec.ExternalReference;
 import com.palantir.conjure.spec.HttpMethod;
 import com.palantir.conjure.spec.ListType;
@@ -479,8 +480,9 @@ public enum EndpointDefinitionValidator implements ConjureContextualValidator<En
         public void validate(EndpointDefinition definition) {
             Set<String> endpointErrorNameAndNamespaces = new HashSet<>();
             for (EndpointError endpointErrorDef : definition.getErrors()) {
-                String errorName = endpointErrorDef.getName();
-                String errorNamespace = endpointErrorDef.getNamespace().get();
+                ErrorTypeName errorTypeName = endpointErrorDef.getError();
+                String errorName = errorTypeName.getName();
+                String errorNamespace = errorTypeName.getNamespace().get();
                 String errorUniqueId = errorName + ":" + errorNamespace;
                 Preconditions.checkArgument(
                         endpointErrorNameAndNamespaces.add(errorUniqueId),

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/services/EndpointDefinition.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/services/EndpointDefinition.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.palantir.conjure.defs.ConjureImmutablesStyle;
 import com.palantir.conjure.parser.types.ConjureType;
 import com.palantir.logsafe.Unsafe;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -42,6 +43,8 @@ public interface EndpointDefinition {
     Set<ConjureType> markers();
 
     Optional<ConjureType> returns();
+
+    List<EndpointError> errors();
 
     Optional<String> docs();
 

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/services/EndpointError.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/services/EndpointError.java
@@ -16,7 +16,6 @@
 
 package com.palantir.conjure.parser.services;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
@@ -33,13 +32,12 @@ import org.immutables.value.Value;
 @Value.Immutable
 @ConjureImmutablesStyle
 public interface EndpointError {
-    @JsonProperty("error-name")
-    ConjureType errorName();
+    ConjureType error();
 
     Optional<String> docs();
 
     static EndpointError of(ConjureType errorName) {
-        return ImmutableEndpointError.builder().errorName(errorName).build();
+        return ImmutableEndpointError.builder().error(errorName).build();
     }
 
     // TODO(pm): see if there's something we can do with @JsonCreator.

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/services/EndpointError.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/services/EndpointError.java
@@ -16,19 +16,14 @@
 
 package com.palantir.conjure.parser.services;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.palantir.conjure.defs.ConjureImmutablesStyle;
-import com.palantir.conjure.parser.services.EndpointError.EndpointErrorDeserializer;
+import com.palantir.conjure.parser.services.ImmutableEndpointError.Json;
 import com.palantir.conjure.parser.types.ConjureType;
 import com.palantir.parsec.ParseException;
-import java.io.IOException;
 import java.util.Optional;
 import org.immutables.value.Value;
 
-@JsonDeserialize(using = EndpointErrorDeserializer.class)
 @Value.Immutable
 @ConjureImmutablesStyle
 public interface EndpointError {
@@ -40,21 +35,17 @@ public interface EndpointError {
         return ImmutableEndpointError.builder().error(errorName).build();
     }
 
-    // TODO(pm): see if there's something we can do with @JsonCreator.
-    final class EndpointErrorDeserializer extends JsonDeserializer<EndpointError> {
-        @Override
-        public EndpointError deserialize(JsonParser parser, DeserializationContext _context) throws IOException {
-
-            String candidate = parser.getValueAsString();
-            if (candidate != null) {
-                try {
-                    return EndpointError.of(ConjureType.fromString(candidate));
-                } catch (ParseException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-
-            return ImmutableEndpointError.fromJson(parser.readValueAs(ImmutableEndpointError.Json.class));
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    static EndpointError fromString(String error) {
+        try {
+            return EndpointError.of(ConjureType.fromString(error));
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
         }
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    static EndpointError fromJson(Json json) {
+        return ImmutableEndpointError.fromJson(json);
     }
 }

--- a/conjure-core/src/main/java/com/palantir/conjure/parser/services/EndpointError.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/services/EndpointError.java
@@ -1,0 +1,62 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.parser.services;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.palantir.conjure.defs.ConjureImmutablesStyle;
+import com.palantir.conjure.parser.services.EndpointError.EndpointErrorDeserializer;
+import com.palantir.conjure.parser.types.ConjureType;
+import com.palantir.parsec.ParseException;
+import java.io.IOException;
+import java.util.Optional;
+import org.immutables.value.Value;
+
+@JsonDeserialize(using = EndpointErrorDeserializer.class)
+@Value.Immutable
+@ConjureImmutablesStyle
+public interface EndpointError {
+    @JsonProperty("error-name")
+    ConjureType errorName();
+
+    Optional<String> docs();
+
+    static EndpointError of(ConjureType errorName) {
+        return ImmutableEndpointError.builder().errorName(errorName).build();
+    }
+
+    // TODO(pm): see if there's something we can do with @JsonCreator.
+    final class EndpointErrorDeserializer extends JsonDeserializer<EndpointError> {
+        @Override
+        public EndpointError deserialize(JsonParser parser, DeserializationContext _context) throws IOException {
+
+            String candidate = parser.getValueAsString();
+            if (candidate != null) {
+                try {
+                    return EndpointError.of(ConjureType.fromString(candidate));
+                } catch (ParseException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            return ImmutableEndpointError.fromJson(parser.readValueAs(ImmutableEndpointError.Json.class));
+        }
+    }
+}

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/ConjureDefTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/ConjureDefTest.java
@@ -113,23 +113,26 @@ public class ConjureDefTest {
                             .satisfies(endpointDefinition -> assertThat(endpointDefinition.getErrors())
                                     .containsExactlyInAnyOrder(
                                             EndpointError.builder()
-                                                    .error(com.palantir.conjure.spec.TypeName.of(
-                                                            "Error2", "test.api.with.imported.errors"))
+                                                    .name("Error2")
+                                                    .package_("test.api.with.imported.errors")
                                                     .namespace(com.palantir.conjure.spec.ErrorNamespace.of(
                                                             "TestNamespace"))
                                                     .build(),
                                             // The InvalidArgument is imported from the `test.api` package.
-                                            EndpointError.of(
-                                                    com.palantir.conjure.spec.TypeName.of(
-                                                            "InvalidArgument", "test.api"),
-                                                    com.palantir.conjure.spec.ErrorNamespace.of("Test"),
-                                                    Documentation.of("Docs for the imported error")),
-                                            EndpointError.of(
-                                                    com.palantir.conjure.spec.TypeName.of(
-                                                            "InvalidArgument", "test.api.with.imported.errors"),
-                                                    com.palantir.conjure.spec.ErrorNamespace.of("OtherNamespace"),
-                                                    Documentation.of("An error with the same name is imported from "
-                                                            + "test-service.yml, but has a different namespace."))));
+                                            EndpointError.builder()
+                                                    .name("InvalidArgument")
+                                                    .package_("test.api")
+                                                    .namespace(com.palantir.conjure.spec.ErrorNamespace.of("Test"))
+                                                    .docs(Documentation.of("Docs for the imported error"))
+                                                    .build(),
+                                            EndpointError.builder()
+                                                    .name("InvalidArgument")
+                                                    .package_("test.api.with.imported.errors")
+                                                    .namespace(com.palantir.conjure.spec.ErrorNamespace.of(
+                                                            "OtherNamespace"))
+                                                    .docs(Documentation.of("An error with the same name is imported"
+                                                            + " from test-service.yml, but has a different namespace."))
+                                                    .build()));
                 });
     }
 }

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/ConjureDefTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/ConjureDefTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import com.palantir.conjure.exceptions.ConjureRuntimeException;
 import com.palantir.conjure.parser.ConjureParser;
 import com.palantir.conjure.spec.ConjureDefinition;
+import com.palantir.conjure.spec.Documentation;
 import com.palantir.conjure.spec.EndpointError;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.io.File;
@@ -110,12 +111,17 @@ public class ConjureDefTest {
                     assertThat(serviceDefinition.getEndpoints())
                             .singleElement()
                             .satisfies(endpointDefinition -> assertThat(endpointDefinition.getErrors())
-                                    .extracting(EndpointError::getError)
+                                    // .extracting(EndpointError::getError)
                                     .containsExactlyInAnyOrder(
-                                            // Invalid argument should be from the `test.api` package that was imported.
-                                            com.palantir.conjure.spec.TypeName.of("InvalidArgument", "test.api"),
-                                            com.palantir.conjure.spec.TypeName.of(
-                                                    "Error2", "test.api.with.imported.errors")));
+                                            EndpointError.builder()
+                                                    .error(com.palantir.conjure.spec.TypeName.of(
+                                                            "Error2", "test.api.with.imported.errors"))
+                                                    .build(),
+                                            // The InvalidArgument is imported from the `test.api` package.
+                                            EndpointError.of(
+                                                    com.palantir.conjure.spec.TypeName.of(
+                                                            "InvalidArgument", "test.api"),
+                                                    Documentation.of("Docs for the imported error"))));
                 });
     }
 }

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/ConjureDefTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/ConjureDefTest.java
@@ -110,7 +110,7 @@ public class ConjureDefTest {
                     assertThat(serviceDefinition.getEndpoints())
                             .singleElement()
                             .satisfies(endpointDefinition -> assertThat(endpointDefinition.getErrors())
-                                    .extracting(EndpointError::getErrorName)
+                                    .extracting(EndpointError::getError)
                                     .containsExactlyInAnyOrder(
                                             // Invalid argument should be from the `test.api` package that was imported.
                                             com.palantir.conjure.spec.TypeName.of("InvalidArgument", "test.api"),

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/ConjureDefTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/ConjureDefTest.java
@@ -25,6 +25,8 @@ import com.palantir.conjure.parser.ConjureParser;
 import com.palantir.conjure.spec.ConjureDefinition;
 import com.palantir.conjure.spec.Documentation;
 import com.palantir.conjure.spec.EndpointError;
+import com.palantir.conjure.spec.ErrorNamespace;
+import com.palantir.conjure.spec.ErrorTypeName;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.io.File;
 import org.junit.Ignore;
@@ -113,23 +115,27 @@ public class ConjureDefTest {
                             .satisfies(endpointDefinition -> assertThat(endpointDefinition.getErrors())
                                     .containsExactlyInAnyOrder(
                                             EndpointError.builder()
-                                                    .name("Error2")
-                                                    .package_("test.api.with.imported.errors")
-                                                    .namespace(com.palantir.conjure.spec.ErrorNamespace.of(
-                                                            "TestNamespace"))
+                                                    .error(ErrorTypeName.builder()
+                                                            .name("Error2")
+                                                            .package_("test.api.with.imported.errors")
+                                                            .namespace(ErrorNamespace.of("TestNamespace"))
+                                                            .build())
                                                     .build(),
                                             // The InvalidArgument is imported from the `test.api` package.
                                             EndpointError.builder()
-                                                    .name("InvalidArgument")
-                                                    .package_("test.api")
-                                                    .namespace(com.palantir.conjure.spec.ErrorNamespace.of("Test"))
+                                                    .error(ErrorTypeName.builder()
+                                                            .name("InvalidArgument")
+                                                            .package_("test.api")
+                                                            .namespace(ErrorNamespace.of("Test"))
+                                                            .build())
                                                     .docs(Documentation.of("Docs for the imported error"))
                                                     .build(),
                                             EndpointError.builder()
-                                                    .name("InvalidArgument")
-                                                    .package_("test.api.with.imported.errors")
-                                                    .namespace(com.palantir.conjure.spec.ErrorNamespace.of(
-                                                            "OtherNamespace"))
+                                                    .error(ErrorTypeName.builder()
+                                                            .name("InvalidArgument")
+                                                            .package_("test.api.with.imported.errors")
+                                                            .namespace(ErrorNamespace.of("OtherNamespace"))
+                                                            .build())
                                                     .docs(Documentation.of("An error with the same name is imported"
                                                             + " from test-service.yml, but has a different namespace."))
                                                     .build()));

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/ConjureDefTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/ConjureDefTest.java
@@ -17,10 +17,14 @@
 package com.palantir.conjure.defs;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableList;
+import com.palantir.conjure.exceptions.ConjureRuntimeException;
 import com.palantir.conjure.parser.ConjureParser;
 import com.palantir.conjure.spec.ConjureDefinition;
+import com.palantir.conjure.spec.EndpointError;
+import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.io.File;
 import org.junit.Ignore;
 import org.junit.jupiter.api.Test;
@@ -70,5 +74,48 @@ public class ConjureDefTest {
         ConjureDefinition conjureDefinition = ConjureParserUtils.parseConjureDef(
                 ConjureParser.parseAnnotated(new File("src/test/resources/nameless-test-service.yml")));
         assertThat(conjureDefinition.getServices()).hasSize(1);
+    }
+
+    @Test
+    public void testThrowsWhenEndpointErrorDefinitionNotAReference() {
+        assertThatThrownBy(() -> ConjureParserUtils.parseConjureDef(ConjureParser.parseAnnotated(
+                        new File("src/test/resources/example-non-reference-endpoint-error.yml"))))
+                .isInstanceOf(ConjureRuntimeException.class)
+                .rootCause()
+                .isInstanceOf(SafeIllegalArgumentException.class)
+                .hasMessage("Unsupported endpoint error type. Endpoint errors must be references to a Conjure-defined "
+                        + "error type: {type=INTEGER}");
+    }
+
+    @Test
+    public void testThrowsWhenEndpointErrorIsUndefined() {
+        assertThatThrownBy(() -> ConjureParserUtils.parseConjureDef(ConjureParser.parseAnnotated(
+                        new File("src/test/resources/example-non-existent-endpoint-error.yml"))))
+                .isInstanceOf(ConjureRuntimeException.class)
+                .rootCause()
+                .isInstanceOf(SafeIllegalArgumentException.class)
+                .hasMessage("Unknown error: {error=NonExistentError}");
+    }
+
+    @Test
+    public void testEndpointErrorsCanBeImported() {
+        ConjureDefinition conjureDefinition = ConjureParserUtils.parseConjureDef(
+                ConjureParser.parseAnnotated(new File("src/test/resources/example-imported-endpoint-error.yml")));
+
+        assertThat(conjureDefinition.getServices())
+                .filteredOn(serviceDefinition ->
+                        serviceDefinition.getServiceName().getName().equals("TestService"))
+                .singleElement()
+                .satisfies(serviceDefinition -> {
+                    assertThat(serviceDefinition.getEndpoints())
+                            .singleElement()
+                            .satisfies(endpointDefinition -> assertThat(endpointDefinition.getErrors())
+                                    .extracting(EndpointError::getErrorName)
+                                    .containsExactlyInAnyOrder(
+                                            // Invalid argument should be from the `test.api` package that was imported.
+                                            com.palantir.conjure.spec.TypeName.of("InvalidArgument", "test.api"),
+                                            com.palantir.conjure.spec.TypeName.of(
+                                                    "Error2", "test.api.with.imported.errors")));
+                });
     }
 }

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/ConjureDefTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/ConjureDefTest.java
@@ -111,17 +111,25 @@ public class ConjureDefTest {
                     assertThat(serviceDefinition.getEndpoints())
                             .singleElement()
                             .satisfies(endpointDefinition -> assertThat(endpointDefinition.getErrors())
-                                    // .extracting(EndpointError::getError)
                                     .containsExactlyInAnyOrder(
                                             EndpointError.builder()
                                                     .error(com.palantir.conjure.spec.TypeName.of(
                                                             "Error2", "test.api.with.imported.errors"))
+                                                    .namespace(com.palantir.conjure.spec.ErrorNamespace.of(
+                                                            "TestNamespace"))
                                                     .build(),
                                             // The InvalidArgument is imported from the `test.api` package.
                                             EndpointError.of(
                                                     com.palantir.conjure.spec.TypeName.of(
                                                             "InvalidArgument", "test.api"),
-                                                    Documentation.of("Docs for the imported error"))));
+                                                    com.palantir.conjure.spec.ErrorNamespace.of("Test"),
+                                                    Documentation.of("Docs for the imported error")),
+                                            EndpointError.of(
+                                                    com.palantir.conjure.spec.TypeName.of(
+                                                            "InvalidArgument", "test.api.with.imported.errors"),
+                                                    com.palantir.conjure.spec.ErrorNamespace.of("OtherNamespace"),
+                                                    Documentation.of("An error with the same name is imported from "
+                                                            + "test-service.yml, but has a different namespace."))));
                 });
     }
 }

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/validator/EndpointDefinitionTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/validator/EndpointDefinitionTest.java
@@ -357,19 +357,20 @@ public final class EndpointDefinitionTest {
 
     @Test
     public void testDuplicateEndpointErrorsAreInvalid() {
-        TypeName errorType = TypeName.of("Error1", "test.api");
         EndpointDefinition definition = EndpointDefinition.builder()
                 .endpointName(ENDPOINT_NAME)
                 .httpMethod(HttpMethod.GET)
                 .httpPath(HttpPath.of("/get"))
                 .errors(List.of(
                         EndpointError.builder()
-                                .error(errorType)
+                                .name("Error1")
+                                .package_("test.api")
                                 .docs(Documentation.of("docs"))
                                 .namespace(ErrorNamespace.of("Test"))
                                 .build(),
                         EndpointError.builder()
-                                .error(errorType)
+                                .name("Error1")
+                                .package_("test.api")
                                 .namespace(ErrorNamespace.of("Test"))
                                 .docs(Documentation.of("different docs but same error"))
                                 .build()))
@@ -384,18 +385,19 @@ public final class EndpointDefinitionTest {
 
     @Test
     public void testErrorsAreIdentifiedByNameAndNamespace() {
-        TypeName errorType = TypeName.of("Error1", "test.api");
         EndpointDefinition definition = EndpointDefinition.builder()
                 .endpointName(ENDPOINT_NAME)
                 .httpMethod(HttpMethod.GET)
                 .httpPath(HttpPath.of("/get"))
                 .errors(List.of(
                         EndpointError.builder()
-                                .error(errorType)
+                                .name("Error1")
+                                .package_("test.api")
                                 .namespace(ErrorNamespace.of("Test"))
                                 .build(),
                         EndpointError.builder()
-                                .error(errorType)
+                                .name("Error1")
+                                .package_("test.api")
                                 .namespace(ErrorNamespace.of("TestTwo"))
                                 .build()))
                 .build();

--- a/conjure-core/src/test/java/com/palantir/conjure/parser/services/ServiceDefinitionTests.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/parser/services/ServiceDefinitionTests.java
@@ -26,6 +26,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 import com.palantir.conjure.parser.ConjureParser;
 import com.palantir.conjure.parser.ConjureSourceFile;
+import com.palantir.conjure.parser.services.ArgumentDefinition.ParamType;
 import com.palantir.conjure.parser.types.BaseObjectTypeDefinition;
 import com.palantir.conjure.parser.types.NamedTypesDefinition;
 import com.palantir.conjure.parser.types.TypesDefinition;
@@ -33,10 +34,13 @@ import com.palantir.conjure.parser.types.builtin.AnyType;
 import com.palantir.conjure.parser.types.collect.MapType;
 import com.palantir.conjure.parser.types.complex.EnumTypeDefinition;
 import com.palantir.conjure.parser.types.complex.EnumValueDefinition;
+import com.palantir.conjure.parser.types.complex.ErrorTypeDefinition;
 import com.palantir.conjure.parser.types.complex.FieldDefinition;
 import com.palantir.conjure.parser.types.complex.ObjectTypeDefinition;
 import com.palantir.conjure.parser.types.complex.UnionTypeDefinition;
 import com.palantir.conjure.parser.types.names.ConjurePackage;
+import com.palantir.conjure.parser.types.names.ErrorCode;
+import com.palantir.conjure.parser.types.names.ErrorNamespace;
 import com.palantir.conjure.parser.types.names.FieldName;
 import com.palantir.conjure.parser.types.names.TypeName;
 import com.palantir.conjure.parser.types.primitive.PrimitiveType;
@@ -46,6 +50,7 @@ import com.palantir.conjure.parser.types.reference.LocalReferenceType;
 import com.palantir.parsec.ParseException;
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public final class ServiceDefinitionTests {
@@ -266,6 +271,18 @@ public final class ServiceDefinitionTests {
                                                 AliasTypeDefinition.builder()
                                                         .alias(PrimitiveType.STRING)
                                                         .build())
+                                        .putErrors(
+                                                TypeName.of("InvalidArgument"),
+                                                ErrorTypeDefinition.builder()
+                                                        .namespace(ErrorNamespace.of("Test"))
+                                                        .code(ErrorCode.of("INVALID_ARGUMENT"))
+                                                        .safeArgs(ImmutableMap.of(
+                                                                FieldName.of("field"),
+                                                                FieldDefinition.of(PrimitiveType.STRING)))
+                                                        .unsafeArgs(ImmutableMap.of(
+                                                                FieldName.of("value"),
+                                                                FieldDefinition.of(PrimitiveType.STRING)))
+                                                        .build())
                                         .build())
                                 .build())
                         .putServices(
@@ -277,6 +294,8 @@ public final class ServiceDefinitionTests {
                                                 "get",
                                                 EndpointDefinition.builder()
                                                         .http(RequestLineDefinition.of("GET", PathString.of("/get")))
+                                                        .errors(List.of(EndpointError.of(
+                                                                LocalReferenceType.of(TypeName.of("InvalidArgument")))))
                                                         .build())
                                         .putEndpoints(
                                                 "post",
@@ -287,7 +306,7 @@ public final class ServiceDefinitionTests {
                                                                 ParameterName.of("foo"),
                                                                 ArgumentDefinition.builder()
                                                                         .paramId(ParameterName.of("Foo"))
-                                                                        .paramType(ArgumentDefinition.ParamType.HEADER)
+                                                                        .paramType(ParamType.HEADER)
                                                                         .type(LocalReferenceType.of(
                                                                                 TypeName.of("StringAlias")))
                                                                         .addTags("safe")

--- a/conjure-core/src/test/resources/example-imported-endpoint-error.yml
+++ b/conjure-core/src/test/resources/example-imported-endpoint-error.yml
@@ -4,11 +4,11 @@ types:
   definitions:
     default-package: test.api.with.imported.errors
     errors:
-        Error2:
-          namespace: Test
-          code: INVALID_ARGUMENT
-          safe-args:
-            id: integer
+      Error2:
+        namespace: Test
+        code: INVALID_ARGUMENT
+        safe-args:
+          id: integer
 
 services:
   TestService:

--- a/conjure-core/src/test/resources/example-imported-endpoint-error.yml
+++ b/conjure-core/src/test/resources/example-imported-endpoint-error.yml
@@ -5,10 +5,17 @@ types:
     default-package: test.api.with.imported.errors
     errors:
       Error2:
-        namespace: Test
+        namespace: TestNamespace
         code: INVALID_ARGUMENT
         safe-args:
           id: integer
+      InvalidArgument:
+        namespace: OtherNamespace
+        code: INVALID_ARGUMENT
+        safe-args:
+          field: string
+        unsafe-args:
+          value: string
 
 services:
   TestService:
@@ -23,3 +30,5 @@ services:
           - error: imports.InvalidArgument
             docs: Docs for the imported error
           - Error2
+          - error: InvalidArgument
+            docs: An error with the same name is imported from test-service.yml, but has a different namespace.

--- a/conjure-core/src/test/resources/example-imported-endpoint-error.yml
+++ b/conjure-core/src/test/resources/example-imported-endpoint-error.yml
@@ -20,5 +20,6 @@ services:
         http: GET /string
         returns: string
         errors:
-          - imports.InvalidArgument
+          - error: imports.InvalidArgument
+            docs: Docs for the imported error
           - Error2

--- a/conjure-core/src/test/resources/example-imported-endpoint-error.yml
+++ b/conjure-core/src/test/resources/example-imported-endpoint-error.yml
@@ -1,0 +1,24 @@
+types:
+  conjure-imports:
+    imports: test-service.yml
+  definitions:
+    default-package: test.api.with.imported.errors
+    errors:
+        Error2:
+          namespace: Test
+          code: INVALID_ARGUMENT
+          safe-args:
+            id: integer
+
+services:
+  TestService:
+    name: Test Service
+    package: test.api.with.imported.errors
+    base-path: /test
+    endpoints:
+      getWithImportedError:
+        http: GET /string
+        returns: string
+        errors:
+          - imports.InvalidArgument
+          - Error2

--- a/conjure-core/src/test/resources/example-non-existent-endpoint-error.yml
+++ b/conjure-core/src/test/resources/example-non-existent-endpoint-error.yml
@@ -1,0 +1,21 @@
+types:
+  definitions:
+    default-package: test.api
+    errors:
+      Error1:
+        namespace: Test
+        code: INVALID_ARGUMENT
+        safe-args:
+          id: integer
+
+services:
+  MyService:
+    name: Test Service
+    package: test.api
+    endpoints:
+      get:
+        http: GET /get
+        returns: string
+        errors:
+          - Error1
+          - NonExistentError

--- a/conjure-core/src/test/resources/example-non-reference-endpoint-error.yml
+++ b/conjure-core/src/test/resources/example-non-reference-endpoint-error.yml
@@ -1,0 +1,10 @@
+services:
+  MyService:
+    name: Test Service
+    package: test.api
+    endpoints:
+      get:
+        http: GET /get
+        returns: string
+        errors:
+          - integer

--- a/conjure-core/src/test/resources/normalized.conjure.json
+++ b/conjure-core/src/test/resources/normalized.conjure.json
@@ -81,6 +81,7 @@
       "httpMethod" : "GET",
       "httpPath" : "/get",
       "args" : [ ],
+      "errors" : [ ],
       "markers" : [ ],
       "tags" : [ ]
     } ]
@@ -94,6 +95,7 @@
       "httpMethod" : "GET",
       "httpPath" : "/get",
       "args" : [ ],
+      "errors" : [ ],
       "markers" : [ ],
       "tags" : [ ]
     } ]

--- a/conjure-core/src/test/resources/spec-tests/services.yml
+++ b/conjure-core/src/test/resources/spec-tests/services.yml
@@ -235,6 +235,38 @@ positive:
                   param-id: ParamId
                   param-type: header
                   type: optional<Long>
+  allowEndpointErrors:
+    conjure:
+      types:
+        definitions:
+          default-package: foo
+          errors:
+            InvalidUserSuppliedArg:
+              namespace: TestErrors
+              code: INVALID_ARGUMENT
+              safe-args:
+                field: string
+              unsafe-args:
+                value: string
+            ResourceNotFound:
+              namespace: TestErrors
+              code: NOT_FOUND
+              safe-args:
+                resource: string
+              unsafe-args:
+                user: optional<string>
+      services:
+        Unused:
+          name: Unused
+          package: unused
+          endpoints:
+            getString:
+              http: GET /string
+              returns: string
+              errors:
+                - InvalidUserSuppliedArg
+                - error-name: ResourceNotFound
+                  docs: Some endpoint documentation here.
 
 negative:
   disallowBearerTokenInPathParams:

--- a/conjure-core/src/test/resources/spec-tests/services.yml
+++ b/conjure-core/src/test/resources/spec-tests/services.yml
@@ -265,7 +265,7 @@ positive:
               returns: string
               errors:
                 - InvalidUserSuppliedArg
-                - error-name: ResourceNotFound
+                - error: ResourceNotFound
                   docs: Some endpoint documentation here.
 
 negative:

--- a/conjure-core/src/test/resources/test-service.yml
+++ b/conjure-core/src/test/resources/test-service.yml
@@ -14,7 +14,14 @@ types:
 
       StringAlias:
         alias: string
-
+    errors:
+      InvalidArgument:
+        namespace: Test
+        code: INVALID_ARGUMENT
+        safe-args:
+          field: string
+        unsafe-args:
+          value: string
 services:
   MyTestService:
     name: Test Service
@@ -23,6 +30,8 @@ services:
     endpoints:
       get:
         http: GET /get
+        errors:
+          - InvalidArgument
 
       post:
         tags: ['test-tag']

--- a/conjure.schema.json
+++ b/conjure.schema.json
@@ -526,7 +526,10 @@
         "docs": {
           "$ref": "#/definitions/DocString"
         }
-      }
+      },
+      "required": [
+        "error"
+      ]
     },
     "DocString": {
       "type": "string"

--- a/conjure.schema.json
+++ b/conjure.schema.json
@@ -428,7 +428,7 @@
         "errors": {
           "type": "array",
             "items": {
-              "oneOf": [
+              "anyOf": [
                 {
                   "$ref": "#/definitions/TypeName"
                 },

--- a/conjure.schema.json
+++ b/conjure.schema.json
@@ -425,6 +425,19 @@
         "returns": {
           "$ref": "#/definitions/ConjureType"
         },
+        "errors": {
+          "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/TypeName"
+                },
+                {
+                  "$ref": "#/definitions/EndpointError"
+                }
+              ]
+            }
+        },
         "args": {
           "type": "object",
           "additionalProperties": {
@@ -502,6 +515,18 @@
         "header",
         "query"
       ]
+    },
+    "EndpointError": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/TypeName"
+        },
+        "docs": {
+          "$ref": "#/definitions/DocString"
+        }
+      }
     },
     "DocString": {
       "type": "string"

--- a/conjure/src/test/resources/test-service.yml
+++ b/conjure/src/test/resources/test-service.yml
@@ -36,6 +36,5 @@ services:
       get:
         http: GET /get
         errors:
-          - EndpointError
           - error: EndpointError2
             docs: Some docs here.

--- a/conjure/src/test/resources/test-service.yml
+++ b/conjure/src/test/resources/test-service.yml
@@ -17,6 +17,15 @@ types:
         code: INVALID_ARGUMENT
         safe-args:
           id: integer
+        unsafe-args:
+          unsafeId: integer
+      EndpointError2:
+        namespace: Test
+        code: INVALID_ARGUMENT
+        safe-args:
+          id: integer
+        unsafe-args:
+          unsafeId: integer
 
 services:
   TestService:
@@ -28,3 +37,5 @@ services:
         http: GET /get
         errors:
           - EndpointError
+          - error: EndpointError2
+            docs: Some docs here.

--- a/conjure/src/test/resources/test-service.yml
+++ b/conjure/src/test/resources/test-service.yml
@@ -11,6 +11,12 @@ types:
       SimpleObject:
         fields:
           stringField: string
+    errors:
+      EndpointError:
+        namespace: Test
+        code: INVALID_ARGUMENT
+        safe-args:
+          id: integer
 
 services:
   TestService:
@@ -20,3 +26,5 @@ services:
     endpoints:
       get:
         http: GET /get
+        errors:
+          - EndpointError

--- a/docs/spec/conjure_definitions.md
+++ b/docs/spec/conjure_definitions.md
@@ -30,6 +30,7 @@ The Conjure compiler requires each file to conform to the [ConjureSourceFile][] 
     - [ServiceDefinition][]
       - [AuthDefinition][]
       - [EndpointDefinition][]
+      - [EndpointError][]
       - [ArgumentDefinition][]
       - [ArgumentDefinition.ParamType][]
     - [DocString][]
@@ -278,6 +279,15 @@ safe&#8209;args | Map[`string` &rarr; [FieldDefinition][]&nbsp;or&nbsp;[ConjureT
 unsafe&#8209;args | Map[`string` &rarr; [FieldDefinition][]&nbsp;or&nbsp;[ConjureType][]] | **REQUIRED**. A map from argument names to type names. These arguments are considered unsafe in accordance with the SLS specification. If the value of the field is a `string` it MUST be a type name that exists within the Conjure definition.
 docs | [DocString][] | Documentation for the type. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 
+**Example:**
+
+```yaml
+CategoryNotFound:
+  namespace: com.example
+  code: NOT_FOUND
+  safe-args:
+    allCategories: list<CategoryId>
+```
 
 ## ErrorCode
 [ErrorCode]: #errorcode
@@ -347,6 +357,7 @@ Field | Type | Description
 http | `string` | **REQUIRED** The operation and path for the endpoint. It MUST follow the shorthand `<method> <path>`, where `<method>` is one of GET, DELETE, POST, or PUT, and `<path>` is a [PathString][].
 auth | [AuthDefinition][] | The authentication mechanism for the endpoint. Overrides `default-auth` in [ServiceDefinition][].
 returns | [ConjureType][] | The name of the return type of the endpoint. The value MUST be a type name that exists within the Conjure definition. If not specified, then the endpoint does not return a value.
+errors | List[[EndpointError][]] | The errors that this endpoint may return. The errors listed here should be closely tied to problems that uniquely arise from the generating a response to the endpoint, which clients are expected to handle.
 args | Map[`string` &rarr; [ArgumentDefinition][]&nbsp;or&nbsp;[ConjureType][]] | A map between argument names and argument definitions. If the value of the field is a `string` it MUST be a type name that exists within the Conjure definition. Furthermore, if a `string` the argument will default to `auto` [ArgumentDefinition.ParamType][].
 docs | [DocString][] | Documentation for the endpoint. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 deprecated | [DocString][] | Documentation for the deprecation of the endpoint. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
@@ -362,7 +373,11 @@ createRecipe:
       param-type: body
       type: Recipe
   returns: RecipeId
+  errors:
+    - error: CategoryNotFound
+      docs: A category with the provided category ID was not found.
 ```
+See the example in the [ErrorDefinition][] section for the definition of `CategoryNotFound`
 
 ## ArgumentDefinition
 [ArgumentDefinition]: #argumentdefinition
@@ -417,6 +432,14 @@ A field describing the type of an endpoint parameter. It is a `string` which MUS
 - `header`: defined as a header parameter.
 - `query`: defined as a querystring parameter.
 
+## EndpointError
+[EndpointError]: #endpointerror
+A reference to an [ErrorDefinition][] associated with a service endpoint.
+
+Field | Type | Description
+---|:---:|---
+error |  [TypeName][] | **REQUIRED**. A reference to a Conjure-defined [ErrorDefinition][].
+docs |  [DocString][]  | Documentation for the argument. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 
 ## DocString
 [DocString]: #docstring

--- a/docs/spec/intermediate_representation.md
+++ b/docs/spec/intermediate_representation.md
@@ -364,6 +364,9 @@ parameter name. Each argument definition may have a "docs" key containing string
 Each argument definition may also have a "markers" key, consisting of a list of [types](#representation-of-conjure-types)
 that serve as additional metadata for the argument.
 - "returns": a [representation](#representation-of-conjure-types) of the return type of the endpoint
+- "errors": a list of endpoint errors. Each endpoint error is a reference to a Conjure-defined [error type](#errors).  
+The endpoint error is either a string representing the name of the referenced error, or an object with an "error" field 
+representing the name of the error and an optional "docs" field containing a string with documentation for the error.
 - "docs": string documentation for the endpoint
 - "deprecated": a string explanation indicating the endpoint is deprecated and why
 


### PR DESCRIPTION
## Before this PR
Expand the Conjure specification to support specifying errors that can be thrown on each endpoint.

### Outline of work
This work is a revival of the ideas outlined in [RFC-007](https://github.com/palantir/conjure/blob/master/docs/rfc/007-endpoint-errors.md) and #816.

#### Current Behavior

* Conjure does not associate errors with endpoints. Clients are expected to keep track of errors thrown. Clients can check if the error thrown is an error they expect.
* Conjure-Java serializes the error parameters as a `Map<String, String>` where the key is the parameter name, and the value is the toString representation of the parameter [(source)](https://github.com/palantir/conjure-java-runtime-api/blob/2.55.0/errors/src/main/java/com/palantir/conjure/java/api/errors/SerializableError.java#L126).
    * This conflicts with the Conjure wire spec which says parameters will be serialized a JSON map - the parameter values should be serialized as JSON objects

#### Desired Behavior

* Conjure associates errors to endpoints, so clients know which errors they can expect when making a call to an endpoint. The addition or removal of an error thrown by an endpoint is considered an API break.
* Conjure-Java serializes the error parameters as JSON maps as per the spec.


Note: this work does not cover the generation of Dialogue client-side error handling logic.



The following PRs are relevant:
- This PR introducing the `errors` field on endpoint definitions
- [This PR in `conjure-java`](https://github.com/palantir/conjure-java/pull/2401) generating checked exception code for each endpoint error, and updating the Undertow service interfaces to throw the generated checked exceptions
- [This PR in `conjure-java-runtime-api`](https://github.com/palantir/conjure-java-runtime-api/pull/1262) introducing the abstract `CheckedServiceException` type that is used in the above `conjure-java` PR

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Support specifying errors on endpoints
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

