### PR TITLE
nit: Update javadoc to use literal ampersands

### DIFF
--- a/conjure-core/src/main/java/com/palantir/conjure/parser/ConjureParser.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/parser/ConjureParser.java
@@ -77,14 +77,14 @@ public final class ConjureParser {
     }
 
     /**
-     * Parse file & all imports (recursively).
+     * Parse file {@literal &} all imports (breadth-first).
      */
     public static Map<String, AnnotatedConjureSourceFile> parseAnnotated(File file) {
         return parseAnnotated(ImmutableList.of(file));
     }
 
     /**
-     * Parse all files & imports (breadth-first).
+     * Parse all files {@literal &} imports (breadth-first).
      */
     public static Map<String, AnnotatedConjureSourceFile> parseAnnotated(Collection<File> files) {
         CachingParser parser = new CachingParser();


### PR DESCRIPTION
## Before this PR
When compiling the repository, we get these warnings:

```

> Task :conjure-core:javadoc
/Volumes/git/conjure/conjure-core/src/main/java/com/palantir/conjure/parser/ConjureParser.java:80: warning: invalid input: '&'
     * Parse file & all imports (recursively).
                  ^
/Volumes/git/conjure/conjure-core/src/main/java/com/palantir/conjure/parser/ConjureParser.java:87: warning: invalid input: '&'
     * Parse all files & imports (breadth-first).
                       ^
/Volumes/git/conjure/conjure-core/src/main/java/com/palantir/conjure/parser/ConjureParser.java:80: warning: invalid input: '&'
     * Parse file & all imports (recursively).
                  ^
/Volumes/git/conjure/conjure-core/src/main/java/com/palantir/conjure/parser/ConjureParser.java:87: warning: invalid input: '&'
     * Parse all files & imports (breadth-first).
                       ^
/Volumes/git/conjure/conjure-core/src/main/java/com/palantir/conjure/parser/ConjureParser.java:80: warning: invalid input: '&'
     * Parse file & all imports (recursively).
                  ^
/Volumes/git/conjure/conjure-core/src/main/java/com/palantir/conjure/parser/ConjureParser.java:87: warning: invalid input: '&'
     * Parse all files & imports (breadth-first).
                       ^
6 warnings
```

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
Update javadoc to use literal ampersands

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

