### PR TITLE
Enforce that Conjure error definitions are unique

### DIFF
--- a/changelog/@unreleased/pr-1685.v2.yml
+++ b/changelog/@unreleased/pr-1685.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Enforce that Conjure error definitions are unique
+  links:
+  - https://github.com/palantir/conjure/pull/1685

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/ConjureDefinitionValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/ConjureDefinitionValidator.java
@@ -549,7 +549,8 @@ public enum ConjureDefinitionValidator implements ConjureValidator<ConjureDefini
             }
             return definitions.stream()
                     .map(ErrorDefinition::toString)
-                    .collect(Collectors.joining("\n\t", "defined %n times:\n\t", ""));
+                    .collect(
+                            Collectors.joining("\n\t", String.format("defined %s times:\n\t", definitions.size()), ""));
         }
     }
 }

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ConjureSourceFileValidatorTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ConjureSourceFileValidatorTest.java
@@ -327,6 +327,7 @@ public class ConjureSourceFileValidatorTest {
                 .hasMessageContainingAll(
                         "errors are defined multiple times",
                         "'Namespace:Name'",
+                        "defined 2 times",
                         fieldOne.toString(),
                         fieldTwo.toString());
     }

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ConjureSourceFileValidatorTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ConjureSourceFileValidatorTest.java
@@ -31,6 +31,9 @@ import com.palantir.conjure.spec.ConjureDefinition;
 import com.palantir.conjure.spec.Documentation;
 import com.palantir.conjure.spec.EndpointDefinition;
 import com.palantir.conjure.spec.EndpointName;
+import com.palantir.conjure.spec.ErrorCode;
+import com.palantir.conjure.spec.ErrorDefinition;
+import com.palantir.conjure.spec.ErrorNamespace;
 import com.palantir.conjure.spec.ExternalReference;
 import com.palantir.conjure.spec.FieldDefinition;
 import com.palantir.conjure.spec.FieldName;
@@ -268,6 +271,64 @@ public class ConjureSourceFileValidatorTest {
         assertThatThrownBy(() -> ConjureDefinitionValidator.ILLEGAL_MAP_KEYS.validate(conjureDef))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageStartingWith("Illegal map key found in object Foo");
+    }
+
+    @Test
+    public void testDuplicateErrorNames_differentPackages() {
+        ConjureDefinition conjureDef = ConjureDefinition.builder()
+                .version(1)
+                .errors(ErrorDefinition.builder()
+                        .namespace(ErrorNamespace.of("Namespace"))
+                        .code(ErrorCode.CUSTOM_SERVER)
+                        .errorName(TypeName.of("Name", "com.palantir.one"))
+                        .build())
+                .errors(ErrorDefinition.builder()
+                        .namespace(ErrorNamespace.of("Namespace"))
+                        .code(ErrorCode.CUSTOM_CLIENT)
+                        .errorName(TypeName.of("Name", "com.palantir.two"))
+                        .build())
+                .build();
+
+        assertThatThrownBy(() -> ConjureDefinitionValidator.UNIQUE_ERROR_NAMES.validate(conjureDef))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContainingAll(
+                        "errors are defined multiple times",
+                        "'Namespace:Name': in packages: com.palantir.one, com.palantir.two");
+    }
+
+    @Test
+    public void testDuplicateErrorNames_differentArgs() {
+        FieldDefinition fieldOne = FieldDefinition.builder()
+                .fieldName(FieldName.of("field"))
+                .type(Type.primitive(PrimitiveType.STRING))
+                .build();
+        FieldDefinition fieldTwo = FieldDefinition.builder()
+                .fieldName(FieldName.of("different"))
+                .type(Type.primitive(PrimitiveType.INTEGER))
+                .build();
+        ConjureDefinition conjureDef = ConjureDefinition.builder()
+                .version(1)
+                .errors(ErrorDefinition.builder()
+                        .namespace(ErrorNamespace.of("Namespace"))
+                        .code(ErrorCode.CUSTOM_SERVER)
+                        .errorName(TypeName.of("Name", "com.palantir"))
+                        .safeArgs(fieldOne)
+                        .build())
+                .errors(ErrorDefinition.builder()
+                        .namespace(ErrorNamespace.of("Namespace"))
+                        .code(ErrorCode.CUSTOM_SERVER)
+                        .errorName(TypeName.of("Name", "com.palantir"))
+                        .safeArgs(fieldTwo)
+                        .build())
+                .build();
+
+        assertThatThrownBy(() -> ConjureDefinitionValidator.UNIQUE_ERROR_NAMES.validate(conjureDef))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContainingAll(
+                        "errors are defined multiple times",
+                        "'Namespace:Name'",
+                        fieldOne.toString(),
+                        fieldTwo.toString());
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
No validation that the same error name wasn't used in multiple definitions. Over the wire, clients cannot distinguish between multiple errors when the namespace and name (excluding package) match.

==COMMIT_MSG==
Enforce that Conjure error definitions are unique
==COMMIT_MSG==

## Possible downsides?
This could prevent some repos from rolling out changes if they already have duplicate errors. However this is fairly unlikely, and the failure is self-documenting.
