### PR TITLE
Precompute valid regexes String in FieldNameValidator.validate()

### DIFF
--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/FieldNameValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/FieldNameValidator.java
@@ -18,6 +18,7 @@ package com.palantir.conjure.defs.validator;
 
 import com.google.common.base.Preconditions;
 import com.palantir.conjure.CaseConverter;
+import com.palantir.conjure.CaseConverter.Case;
 import com.palantir.conjure.spec.FieldName;
 import java.util.Arrays;
 import org.apache.commons.lang3.StringUtils;
@@ -27,6 +28,8 @@ import org.slf4j.LoggerFactory;
 public final class FieldNameValidator {
 
     private static final Logger log = LoggerFactory.getLogger(FieldNameValidator.class);
+    // Precompute this String because otherwise it is computed for every call to validate() and appears in JFRs.
+    private static final String CASE_VALUES = Arrays.toString(Case.values());
 
     private FieldNameValidator() {}
 
@@ -53,7 +56,7 @@ public final class FieldNameValidator {
                         || CaseConverter.SNAKE_CASE_PATTERN.matches(fieldName.get()),
                 "FieldName \"%s\" must follow one of the following patterns: %s",
                 fieldName,
-                Arrays.toString(CaseConverter.Case.values()));
+                CASE_VALUES);
 
         if (!matchesCamelCase) {
             log.warn(

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/validator/FieldNameValidatorTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/validator/FieldNameValidatorTest.java
@@ -40,7 +40,7 @@ public final class FieldNameValidatorTest {
     }
 
     @Test
-    public void testInvalidNames() throws Exception {
+    public void testInvalidNames() {
         for (String invalid : new String[] {
             "UpperCamelCase",
             "Upper-Kebab-Case",
@@ -55,18 +55,22 @@ public final class FieldNameValidatorTest {
         }) {
             assertThatThrownBy(() -> FieldNameValidator.validate(FieldName.of(invalid)))
                     .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessageContaining(
-                            String.format("FieldName \"%s\" must follow one of the following patterns", invalid));
+                    .hasMessageContaining(String.format(
+                            "FieldName \"%s\" must follow one of the following patterns: "
+                                    + "[LOWER_CAMEL_CASE[^[a-z]([A-Z]{1,2}[a-z0-9]|[a-z0-9])*[A-Z]?$], "
+                                    + "KEBAB_CASE[^[a-z]((-[a-z]){1,2}[a-z0-9]|[a-z0-9])*(-[a-z])?$], "
+                                    + "SNAKE_CASE[^[a-z]((_[a-z]){1,2}[a-z0-9]|[a-z0-9])*(_[a-z])?$]]",
+                            invalid));
         }
     }
 
     @Test
-    public void capitalize_should_turn_camel_case_into_sensible_class_name() throws Exception {
+    public void capitalize_should_turn_camel_case_into_sensible_class_name() {
         assertThat(FieldNameValidator.capitalize(FieldName.of("myVariant"))).isEqualTo("MyVariant");
     }
 
     @Test
-    public void capitalize_capture_unused_behavior() throws Exception {
+    public void capitalize_capture_unused_behavior() {
         assertThat(FieldNameValidator.capitalize(FieldName.of("my-variant"))).isEqualTo("My-variant");
         assertThat(FieldNameValidator.capitalize(FieldName.of("my_variant"))).isEqualTo("My_variant");
     }


### PR DESCRIPTION
## Before this PR
This String containing the list of valid case pattern regexes is recomputed for every call to FieldNameValidator.validate(), and appears in JFRs of the gradle daemon:

![Screenshot 2025-01-10 at 10 07 53 PM](https://github.com/user-attachments/assets/bbabca04-0045-4eab-a51c-ca3f3388a11a)

(not a lot, but a little at least)

## After this PR
==COMMIT_MSG==
Precompute valid regexes String in FieldNameValidator.validate()
==COMMIT_MSG==

## Possible downsides?
None known