### PR TITLE
Fix docs for union member casing

### DIFF
--- a/docs/spec/conjure_definitions.md
+++ b/docs/spec/conjure_definitions.md
@@ -233,8 +233,8 @@ It is common for a generator to also generate a visitor interface for each union
 Payload:
   package: com.palantir.example
   union:
-    serviceLog: ServiceLog
-    notAServiceLog: RequestLog
+    ServiceLog: ServiceLog
+    NotAServiceLog: RequestLog
 ```
 
 

--- a/docs/spec/conjure_definitions.md
+++ b/docs/spec/conjure_definitions.md
@@ -222,7 +222,7 @@ Definition for a union complex data type.
 
 Field | Type | Description
 ---------- | ---- | -----------
-union | Map[`string` &rarr; [FieldDefinition][] or [ConjureType][]] | **REQUIRED**. A map from union names to type names. If the value of the field is a `string` it MUST be a type name that exists within the Conjure definition. Union names MUST be in PascalCase.
+union | Map[`string` &rarr; [FieldDefinition][] or [ConjureType][]] | **REQUIRED**. A map from union names to type names. If the value of the field is a `string` it MUST be a type name that exists within the Conjure definition. Union names MUST be in [camelCase](https://developer.mozilla.org/en-US/docs/Glossary/Camel_case).
 docs | [DocString][] | Documentation for the type. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 package | `string` | **REQUIRED** if `default-package` is not specified. Overrides the `default-package` in [NamedTypesDefinition][].
 
@@ -233,8 +233,8 @@ It is common for a generator to also generate a visitor interface for each union
 Payload:
   package: com.palantir.example
   union:
-    ServiceLog: ServiceLog
-    NotAServiceLog: RequestLog
+    serviceLog: ServiceLog
+    notAServiceLog: RequestLog
 ```
 
 

--- a/docs/spec/conjure_definitions.md
+++ b/docs/spec/conjure_definitions.md
@@ -222,7 +222,7 @@ Definition for a union complex data type.
 
 Field | Type | Description
 ---------- | ---- | -----------
-union | Map[`string` &rarr; [FieldDefinition][] or [ConjureType][]] | **REQUIRED**. A map from union names to type names. If the value of the field is a `string` it MUST be a type name that exists within the Conjure definition. Union names MUST be in [camelCase](https://developer.mozilla.org/en-US/docs/Glossary/Camel_case).
+union | Map[`string` &rarr; [FieldDefinition][] or [ConjureType][]] | **REQUIRED**. A map from union names to type names. If the value of the field is a `string` it MUST be a type name that exists within the Conjure definition. Union names MUST be in [lowerCamelCase](https://www.techtarget.com/whatis/definition/lowerCamelCase).
 docs | [DocString][] | Documentation for the type. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 package | `string` | **REQUIRED** if `default-package` is not specified. Overrides the `default-package` in [NamedTypesDefinition][].
 

--- a/docs/spec/conjure_definitions.md
+++ b/docs/spec/conjure_definitions.md
@@ -222,7 +222,7 @@ Definition for a union complex data type.
 
 Field | Type | Description
 ---------- | ---- | -----------
-union | Map[`string` &rarr; [FieldDefinition][] or [ConjureType][]] | **REQUIRED**. A map from union names to type names. If the value of the field is a `string` it MUST be a type name that exists within the Conjure definition. Union names MUST be in [lowerCamelCase](https://www.techtarget.com/whatis/definition/lowerCamelCase).
+union | Map[`string` &rarr; [FieldDefinition][] or [ConjureType][]] | **REQUIRED**. A map from union names to type names. If the value of the field is a `string` it MUST be a type name that exists within the Conjure definition. Union names MUST be in lowerCamelCase.
 docs | [DocString][] | Documentation for the type. [CommonMark syntax](http://spec.commonmark.org/) MAY be used for rich text representation.
 package | `string` | **REQUIRED** if `default-package` is not specified. Overrides the `default-package` in [NamedTypesDefinition][].
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
The definitions mentions that "Union names MUST be in PascalCase", however the example given below had the union names in camelCase.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==
~The example now has union names in PascalCase, conforming to the aforementioned convention.~ The docs now mention that the union Names must be in camelCase.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

