### PR TITLE
Fix complex query param validation

### DIFF
--- a/changelog/@unreleased/pr-1752.v2.yml
+++ b/changelog/@unreleased/pr-1752.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Conjure endpoint validator throws for nested container query arguments.
+  links:
+  - https://github.com/palantir/conjure/pull/1752

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/EndpointDefinitionValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/EndpointDefinitionValidator.java
@@ -288,7 +288,7 @@ public enum EndpointDefinitionValidator implements ConjureContextualValidator<En
             definition.getArgs().stream()
                     .filter(entry -> entry.getParamType().accept(ParameterTypeVisitor.IS_QUERY))
                     .forEach(argDefinition -> {
-                        boolean isValid = recursivelyValidate(argDefinition.getType(), dealiasingTypeVisitor);
+                        boolean isValid = recursivelyValidate(argDefinition.getType(), dealiasingTypeVisitor, false);
                         Preconditions.checkState(
                                 isValid,
                                 "Query parameters must be enums, primitives, aliases, list, sets "
@@ -298,7 +298,7 @@ public enum EndpointDefinitionValidator implements ConjureContextualValidator<En
                     });
         }
 
-        private static Boolean recursivelyValidate(Type type, DealiasingTypeVisitor visitor) {
+        private static Boolean recursivelyValidate(Type type, DealiasingTypeVisitor visitor, boolean isNested) {
             return visitor.dealias(type)
                     .fold(
                             typeDefinition -> typeDefinition.accept(TypeDefinitionVisitor.IS_ENUM),
@@ -310,17 +310,17 @@ public enum EndpointDefinitionValidator implements ConjureContextualValidator<En
 
                                 @Override
                                 public Boolean visitOptional(OptionalType value) {
-                                    return recursivelyValidate(value.getItemType(), visitor);
+                                    return !isNested && recursivelyValidate(value.getItemType(), visitor, true);
                                 }
 
                                 @Override
                                 public Boolean visitList(ListType value) {
-                                    return recursivelyValidate(value.getItemType(), visitor);
+                                    return !isNested && recursivelyValidate(value.getItemType(), visitor, true);
                                 }
 
                                 @Override
                                 public Boolean visitSet(SetType value) {
-                                    return recursivelyValidate(value.getItemType(), visitor);
+                                    return !isNested && recursivelyValidate(value.getItemType(), visitor, true);
                                 }
 
                                 @Override

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/EndpointDefinitionValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/EndpointDefinitionValidator.java
@@ -289,10 +289,10 @@ public enum EndpointDefinitionValidator implements ConjureContextualValidator<En
                     .filter(entry -> entry.getParamType().accept(ParameterTypeVisitor.IS_QUERY))
                     .forEach(argDefinition -> {
                         boolean isValid = recursivelyValidate(argDefinition.getType(), dealiasingTypeVisitor, false);
-                        Preconditions.checkState(
+                        Preconditions.checkArgument(
                                 isValid,
                                 "Query parameters must be enums or primitives when de-aliased, or containers of these"
-                                        + " (list, sets, optionals): \"%s\" is not allowed on endpoint %s",
+                                        + " (list, sets, optionals): '%s' is not allowed on endpoint '%s'",
                                 argDefinition.getArgName(),
                                 describe(definition));
                     });

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/EndpointDefinitionValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/EndpointDefinitionValidator.java
@@ -291,8 +291,8 @@ public enum EndpointDefinitionValidator implements ConjureContextualValidator<En
                         boolean isValid = recursivelyValidate(argDefinition.getType(), dealiasingTypeVisitor, false);
                         Preconditions.checkState(
                                 isValid,
-                                "Query parameters must be enums, primitives, aliases, list, sets "
-                                        + "or optional of primitive: \"%s\" is not allowed on endpoint %s",
+                                "Query parameters must be enums or primitives when de-aliased, or containers of these"
+                                        + " (list, sets, optionals): \"%s\" is not allowed on endpoint %s",
                                 argDefinition.getArgName(),
                                 describe(definition));
                     });

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/validator/EndpointDefinitionTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/validator/EndpointDefinitionTest.java
@@ -28,6 +28,8 @@ import com.palantir.conjure.spec.Documentation;
 import com.palantir.conjure.spec.EndpointDefinition;
 import com.palantir.conjure.spec.EndpointError;
 import com.palantir.conjure.spec.EndpointName;
+import com.palantir.conjure.spec.EnumDefinition;
+import com.palantir.conjure.spec.EnumValueDefinition;
 import com.palantir.conjure.spec.ErrorNamespace;
 import com.palantir.conjure.spec.ErrorTypeName;
 import com.palantir.conjure.spec.HeaderParameterType;
@@ -370,6 +372,7 @@ public final class EndpointDefinitionTest {
     @Test
     public void testQueryParamValidatorContainerIsValid() {
         TypeName typeName = TypeName.of("OptionalAlias", "com.palantir.foo");
+        TypeName enumTypeName = TypeName.of("ExampleEnum", "com.palantir.foo");
         EndpointDefinition.Builder definition = EndpointDefinition.builder()
                 .args(ImmutableList.of(ArgumentDefinition.builder()
                         .argName(ArgumentName.of("aliasParam"))
@@ -391,6 +394,11 @@ public final class EndpointDefinitionTest {
                         .type(Type.set(SetType.of(Type.primitive(PrimitiveType.STRING))))
                         .paramType(ParameterType.query(QueryParameterType.of(ParameterId.of("value"))))
                         .build()))
+                .args(ImmutableList.of(ArgumentDefinition.builder()
+                        .argName(ArgumentName.of("listEnum"))
+                        .type(Type.list(ListType.of(Type.reference(enumTypeName))))
+                        .paramType(ParameterType.query(QueryParameterType.of(ParameterId.of("value"))))
+                        .build()))
                 .endpointName(ENDPOINT_NAME)
                 .httpMethod(HttpMethod.GET)
                 .httpPath(HttpPath.of("/path"));
@@ -401,6 +409,12 @@ public final class EndpointDefinitionTest {
                         .typeName(typeName)
                         .alias(Type.list(
                                 ListType.of(Type.optional(OptionalType.of(Type.primitive(PrimitiveType.STRING))))))
+                        .build()),
+                enumTypeName,
+                TypeDefinition.enum_(EnumDefinition.builder()
+                        .typeName(enumTypeName)
+                        .values(List.of(
+                                EnumValueDefinition.builder().value("FOO").build()))
                         .build())));
 
         EndpointDefinitionValidator.validateAll(definition.build(), dealiasingVisitor);

--- a/conjure-core/src/test/resources/spec-tests/services.yml
+++ b/conjure-core/src/test/resources/spec-tests/services.yml
@@ -392,7 +392,7 @@ negative:
               args:
                 foo: set<string>
   disallowMapInQueryParams:
-    expected-error: 'Query parameters must be enums, primitives, aliases, list, sets or optional of primitive: "foo" is not allowed'
+    expected-error: "Query parameters must be enums or primitives when de-aliased, or containers of these (list, sets, optionals): 'foo' is not allowed"
     conjure:
       services:
         Unused:
@@ -430,7 +430,7 @@ negative:
               http: GET /myEndpoint
               returns: optional<optional<string>>
   disallowQueryParamWithNestedOptional:
-      expected-error: "Illegal nested optionals found in one of the arguments of endpoint testEndpoint"
+      expected-error: "Query parameters must be enums or primitives when de-aliased, or containers of these (list, sets, optionals): 'queryName' is not allowed"
       conjure:
         services:
           TestService:


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Conjure endpoint validator allows nested containers in an endpoint query argument, for example: 
```
ArgumentDefinition:
    type: optional<list<string>>
    param-type: query
```
Query params cannot be nested container types, as container inner types must be serialized using PLAIN format, which only supports primitives + enums.

The example above in particular creates ambiguity in the wire format (since types with multiple elements are encoded to urls as a series of individual elements: `?arg=foo,arg=bar`, while optional types are simply omitted from the query string if the value is not present [[docs](https://palantir.github.io/conjure/#/docs/spec/wire?id=_22-query-parameters)]). In this case, an absence of the argument could be either the empty optional or a present optional with an empty list.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Conjure endpoint validator throws for nested container query arguments.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

