### PR TITLE
Filters input files for YAML extensions

### DIFF
--- a/conjure/src/main/java/com/palantir/conjure/cli/CliConfiguration.java
+++ b/conjure/src/main/java/com/palantir/conjure/cli/CliConfiguration.java
@@ -69,15 +69,20 @@ public abstract class CliConfiguration {
     private static Collection<File> resolveInputFiles(File input) throws IOException {
         final Collection<File> inputFiles;
         if (input.isDirectory()) {
-            try (Stream<Path> fileStream = Files.find(input.toPath(), 999, (path, bfa) -> bfa.isRegularFile())) {
+            try (Stream<Path> fileStream =
+                    Files.find(input.toPath(), 999, (path, bfa) -> bfa.isRegularFile() && isYamlFile(path.toFile()))) {
                 inputFiles = fileStream.map(Path::toFile).collect(Collectors.toList());
             }
-        } else if (input.isFile()) {
+        } else if (input.isFile() && isYamlFile(input)) {
             inputFiles = ImmutableList.of(input);
         } else {
-            throw new IOException("Input is not an existing file or directory: " + input);
+            throw new IOException("Input is not an existing YAML file or directory: " + input);
         }
         return inputFiles;
+    }
+
+    private static boolean isYamlFile(File file) {
+        return file.getName().endsWith(".yml") || file.getName().endsWith(".yaml");
     }
 
     public static final class Builder extends ImmutableCliConfiguration.Builder {}

--- a/conjure/src/main/java/com/palantir/conjure/cli/CliConfiguration.java
+++ b/conjure/src/main/java/com/palantir/conjure/cli/CliConfiguration.java
@@ -82,7 +82,7 @@ public abstract class CliConfiguration {
     }
 
     private static boolean isYamlFile(File file) {
-        return file.getName().endsWith(".yml") || file.getName().endsWith(".yaml");
+        return file.getName().endsWith(".yml");
     }
 
     public static final class Builder extends ImmutableCliConfiguration.Builder {}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
Conjure spec declares source files must end in `.yml` ([link](https://github.com/palantir/conjure/blob/c0b8383568ba01803bba7bad87c79d3ab2d3b7cf/docs/spec/conjure_definitions.md?plain=1#L3)). Filtering to YAML types when searching for inputs seems reasonable, filtering out hidden files feels overly prescriptive since its not explicitly declared in the spec. 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Filters input source files to YAML files.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

