### PR TITLE
Add ConjureIrValidator to validate deserialized Conjure IR

### DIFF
--- a/changelog/@unreleased/pr-2149.v2.yml
+++ b/changelog/@unreleased/pr-2149.v2.yml
@@ -1,0 +1,8 @@
+type: feature
+feature:
+  description: Add ConjureIrValidator, which validates an already-built ConjureDefinition
+    the way the compiler validates during parse (per-type identifier, field, package,
+    HTTP-path and endpoint validators plus the cross-cutting checks), so consumers of
+    compiled IR can enforce spec conformance without re-parsing.
+  links:
+  - https://github.com/palantir/conjure/pull/2149

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/ConjureIrValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/ConjureIrValidator.java
@@ -17,6 +17,7 @@
 package com.palantir.conjure.defs.validator;
 
 import com.palantir.conjure.defs.SafetyDeclarationRequirements;
+import com.palantir.conjure.exceptions.ConjureIllegalStateException;
 import com.palantir.conjure.spec.AliasDefinition;
 import com.palantir.conjure.spec.ConjureDefinition;
 import com.palantir.conjure.spec.EnumDefinition;
@@ -42,7 +43,6 @@ public final class ConjureIrValidator {
 
     private ConjureIrValidator() {}
 
-    /** Validates using {@link SafetyDeclarationRequirements#ALLOWED}. */
     public static void validate(ConjureDefinition definition) {
         validate(definition, SafetyDeclarationRequirements.ALLOWED);
     }
@@ -54,7 +54,8 @@ public final class ConjureIrValidator {
         definition.getTypes().forEach(type -> type.accept(TypeValidator.INSTANCE));
         definition.getErrors().forEach(error -> {
             PackageValidator.validate(error.getErrorName().getPackage());
-            // Field names/definitions must be validated before ErrorDefinitionValidator, which normalizes field
+            ErrorNamespaceValidator.validate(error.getNamespace());
+            // Field names/definitions should be validated before ErrorDefinitionValidator, which normalizes field
             // names via FieldNameValidator#toCase and assumes they already conform to the FieldName grammar.
             validateFields(error.getSafeArgs());
             validateFields(error.getUnsafeArgs());
@@ -72,7 +73,6 @@ public final class ConjureIrValidator {
         ConjureDefinitionValidator.validateAll(definition, safetyRequirements);
     }
 
-    /** Validates each field's name and definition, matching the checks the parser applies via its shared helper. */
     private static void validateFields(List<FieldDefinition> fields) {
         fields.forEach(field -> {
             FieldNameValidator.validate(field.getFieldName());
@@ -102,7 +102,7 @@ public final class ConjureIrValidator {
         public Void visitObject(ObjectDefinition value) {
             PackageValidator.validate(value.getTypeName().getPackage());
             TypeNameValidator.validate(value.getTypeName());
-            // Field names/definitions must be validated before ObjectDefinitionValidator, which normalizes field
+            // Field names/definitions should be validated before ObjectDefinitionValidator, which normalizes field
             // names via FieldNameValidator#toCase and assumes they already conform to the FieldName grammar.
             validateFields(value.getFields());
             ObjectDefinitionValidator.validate(value);
@@ -119,8 +119,8 @@ public final class ConjureIrValidator {
         }
 
         @Override
-        public Void visitUnknown(String _unknownType) {
-            return null;
+        public Void visitUnknown(String unknownType) {
+            throw new ConjureIllegalStateException("Unknown type: " + unknownType);
         }
     }
 }

--- a/conjure-core/src/main/java/com/palantir/conjure/defs/validator/ConjureIrValidator.java
+++ b/conjure-core/src/main/java/com/palantir/conjure/defs/validator/ConjureIrValidator.java
@@ -1,0 +1,126 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.defs.validator;
+
+import com.palantir.conjure.defs.SafetyDeclarationRequirements;
+import com.palantir.conjure.spec.AliasDefinition;
+import com.palantir.conjure.spec.ConjureDefinition;
+import com.palantir.conjure.spec.EnumDefinition;
+import com.palantir.conjure.spec.FieldDefinition;
+import com.palantir.conjure.spec.ObjectDefinition;
+import com.palantir.conjure.spec.TypeDefinition;
+import com.palantir.conjure.spec.UnionDefinition;
+import com.palantir.conjure.visitor.DealiasingTypeVisitor;
+import com.palantir.conjure.visitor.TypeDefinitionVisitor;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Validates an already-deserialized {@link ConjureDefinition} the way the compiler validates during parse.
+ *
+ * <p>{@link ConjureDefinitionValidator#validateAll} runs only cross-cutting checks (unique names, version,
+ * recursion, nested optionals, illegal map keys, log-safety). The per-type identifier and format validators are
+ * otherwise invoked only while parsing source. This entry point runs both, so a consumer that deserializes compiled
+ * IR (rather than parsing source) can enforce the same spec conformance.
+ */
+public final class ConjureIrValidator {
+
+    private ConjureIrValidator() {}
+
+    /** Validates using {@link SafetyDeclarationRequirements#ALLOWED}. */
+    public static void validate(ConjureDefinition definition) {
+        validate(definition, SafetyDeclarationRequirements.ALLOWED);
+    }
+
+    public static void validate(ConjureDefinition definition, SafetyDeclarationRequirements safetyRequirements) {
+        DealiasingTypeVisitor dealiasingTypeVisitor = new DealiasingTypeVisitor(definition.getTypes().stream()
+                .collect(Collectors.toMap(type -> type.accept(TypeDefinitionVisitor.TYPE_NAME), Function.identity())));
+
+        definition.getTypes().forEach(type -> type.accept(TypeValidator.INSTANCE));
+        definition.getErrors().forEach(error -> {
+            PackageValidator.validate(error.getErrorName().getPackage());
+            // Field names/definitions must be validated before ErrorDefinitionValidator, which normalizes field
+            // names via FieldNameValidator#toCase and assumes they already conform to the FieldName grammar.
+            validateFields(error.getSafeArgs());
+            validateFields(error.getUnsafeArgs());
+            ErrorDefinitionValidator.validate(error);
+        });
+        definition.getServices().forEach(service -> {
+            PackageValidator.validate(service.getServiceName().getPackage());
+            ServiceDefinitionValidator.validateAll(service);
+            service.getEndpoints().forEach(endpoint -> {
+                HttpPathValidator.validate(endpoint.getHttpPath());
+                EndpointDefinitionValidator.validateAll(endpoint, dealiasingTypeVisitor);
+            });
+        });
+
+        ConjureDefinitionValidator.validateAll(definition, safetyRequirements);
+    }
+
+    /** Validates each field's name and definition, matching the checks the parser applies via its shared helper. */
+    private static void validateFields(List<FieldDefinition> fields) {
+        fields.forEach(field -> {
+            FieldNameValidator.validate(field.getFieldName());
+            FieldDefinitionValidator.validate(field);
+        });
+    }
+
+    private enum TypeValidator implements TypeDefinition.Visitor<Void> {
+        INSTANCE;
+
+        @Override
+        public Void visitAlias(AliasDefinition value) {
+            PackageValidator.validate(value.getTypeName().getPackage());
+            TypeNameValidator.validate(value.getTypeName());
+            return null;
+        }
+
+        @Override
+        public Void visitEnum(EnumDefinition value) {
+            PackageValidator.validate(value.getTypeName().getPackage());
+            TypeNameValidator.validate(value.getTypeName());
+            EnumDefinitionValidator.validateAll(value);
+            return null;
+        }
+
+        @Override
+        public Void visitObject(ObjectDefinition value) {
+            PackageValidator.validate(value.getTypeName().getPackage());
+            TypeNameValidator.validate(value.getTypeName());
+            // Field names/definitions must be validated before ObjectDefinitionValidator, which normalizes field
+            // names via FieldNameValidator#toCase and assumes they already conform to the FieldName grammar.
+            validateFields(value.getFields());
+            ObjectDefinitionValidator.validate(value);
+            return null;
+        }
+
+        @Override
+        public Void visitUnion(UnionDefinition value) {
+            PackageValidator.validate(value.getTypeName().getPackage());
+            TypeNameValidator.validate(value.getTypeName());
+            validateFields(value.getUnion());
+            UnionDefinitionValidator.validateAll(value);
+            return null;
+        }
+
+        @Override
+        public Void visitUnknown(String _unknownType) {
+            return null;
+        }
+    }
+}

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ConjureIrValidatorTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ConjureIrValidatorTest.java
@@ -49,163 +49,45 @@ import org.junit.jupiter.api.Test;
 
 public final class ConjureIrValidatorTest {
 
-    private static final TypeName ENUM_NAME = TypeName.of("Color", "com.example.product");
-
-    @Test
-    public void rejectsEnumValueOutsideGrammar() {
-        ConjureDefinition definition = ConjureDefinition.builder()
-                .version(1)
-                .types(List.of(TypeDefinition.enum_(EnumDefinition.builder()
-                        .typeName(ENUM_NAME)
-                        .values(List.of(
-                                EnumValueDefinition.builder().value("RED").build(),
-                                EnumValueDefinition.builder().value("not valid").build()))
-                        .build())))
-                .build();
-
-        assertThatThrownBy(() -> ConjureIrValidator.validate(definition)).isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    public void rejectsInvalidTypeName() {
-        ConjureDefinition definition = ConjureDefinition.builder()
-                .version(1)
-                .types(List.of(TypeDefinition.enum_(EnumDefinition.builder()
-                        .typeName(TypeName.of("invalid name", "com.example.product"))
-                        .values(List.of(
-                                EnumValueDefinition.builder().value("RED").build()))
-                        .build())))
-                .build();
-
-        assertThatThrownBy(() -> ConjureIrValidator.validate(definition)).isInstanceOf(IllegalArgumentException.class);
-    }
+    private static final String PACKAGE = "com.example.product";
+    private static final TypeName ENUM_NAME = TypeName.of("Color", PACKAGE);
 
     @Test
     public void acceptsValidDefinition() {
         ConjureDefinition definition = ConjureDefinition.builder()
                 .version(1)
-                .types(List.of(TypeDefinition.enum_(EnumDefinition.builder()
-                        .typeName(ENUM_NAME)
-                        .values(List.of(
-                                EnumValueDefinition.builder().value("RED").build(),
-                                EnumValueDefinition.builder().value("GREEN").build()))
-                        .build())))
-                .build();
-
-        assertThatCode(() -> ConjureIrValidator.validate(definition)).doesNotThrowAnyException();
-    }
-
-    @Test
-    public void rejectsInvalidPackageName() {
-        ConjureDefinition definition = ConjureDefinition.builder()
-                .version(1)
-                .types(List.of(TypeDefinition.enum_(EnumDefinition.builder()
-                        .typeName(TypeName.of("Color", "Foo"))
-                        .values(List.of(
-                                EnumValueDefinition.builder().value("RED").build()))
-                        .build())))
-                .build();
-
-        assertThatThrownBy(() -> ConjureIrValidator.validate(definition)).isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    public void rejectsInvalidFieldName() {
-        ConjureDefinition definition = ConjureDefinition.builder()
-                .version(1)
-                .types(List.of(TypeDefinition.object(ObjectDefinition.builder()
-                        .typeName(TypeName.of("Widget", "com.example.product"))
-                        .fields(FieldDefinition.builder()
-                                .fieldName(FieldName.of("not valid"))
-                                .type(Type.primitive(PrimitiveType.STRING))
-                                .build())
-                        .build())))
-                .build();
-
-        assertThatThrownBy(() -> ConjureIrValidator.validate(definition)).isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    public void rejectsInvalidHttpPath() {
-        ConjureDefinition definition = ConjureDefinition.builder()
-                .version(1)
-                .services(List.of(ServiceDefinition.builder()
-                        .serviceName(TypeName.of("WidgetService", "com.example.product"))
-                        .endpoints(EndpointDefinition.builder()
-                                .endpointName(EndpointName.of("getWidget"))
-                                .httpMethod(HttpMethod.GET)
-                                .httpPath(HttpPath.of("widget"))
-                                .build())
-                        .build()))
-                .build();
-
-        assertThatThrownBy(() -> ConjureIrValidator.validate(definition)).isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    public void acceptsValidDefinitionWithObjectAndService() {
-        ConjureDefinition definition = ConjureDefinition.builder()
-                .version(1)
-                .types(List.of(TypeDefinition.object(ObjectDefinition.builder()
-                        .typeName(TypeName.of("Widget", "com.example.product"))
-                        .fields(FieldDefinition.builder()
-                                .fieldName(FieldName.of("displayName"))
-                                .type(Type.primitive(PrimitiveType.STRING))
-                                .build())
-                        .build())))
-                .services(List.of(ServiceDefinition.builder()
-                        .serviceName(TypeName.of("WidgetService", "com.example.product"))
-                        .endpoints(EndpointDefinition.builder()
-                                .endpointName(EndpointName.of("getWidget"))
-                                .httpMethod(HttpMethod.GET)
-                                .httpPath(HttpPath.of("/widget"))
-                                .build())
-                        .build()))
-                .build();
-
-        assertThatCode(() -> ConjureIrValidator.validate(definition)).doesNotThrowAnyException();
-    }
-
-    @Test
-    public void rejectsInvalidFieldNameInError() {
-        ConjureDefinition definition = ConjureDefinition.builder()
-                .version(1)
+                .types(List.of(
+                        TypeDefinition.enum_(EnumDefinition.builder()
+                                .typeName(ENUM_NAME)
+                                .values(List.of(
+                                        EnumValueDefinition.builder()
+                                                .value("RED")
+                                                .build(),
+                                        EnumValueDefinition.builder()
+                                                .value("GREEN")
+                                                .build()))
+                                .build()),
+                        TypeDefinition.object(ObjectDefinition.builder()
+                                .typeName(TypeName.of("Widget", PACKAGE))
+                                .fields(FieldDefinition.builder()
+                                        .fieldName(FieldName.of("displayName"))
+                                        .type(Type.primitive(PrimitiveType.STRING))
+                                        .build())
+                                .build()),
+                        TypeDefinition.union(UnionDefinition.builder()
+                                .typeName(TypeName.of("Shape", PACKAGE))
+                                .union(FieldDefinition.builder()
+                                        .fieldName(FieldName.of("circle"))
+                                        .type(Type.primitive(PrimitiveType.STRING))
+                                        .build())
+                                .build())))
                 .errors(List.of(ErrorDefinition.builder()
-                        .errorName(TypeName.of("WidgetError", "com.example.product"))
+                        .errorName(TypeName.of("WidgetError", PACKAGE))
                         .namespace(ErrorNamespace.of("Widget"))
                         .code(ErrorCode.INVALID_ARGUMENT)
-                        .safeArgs(FieldDefinition.builder()
-                                .fieldName(FieldName.of("not valid"))
-                                .type(Type.primitive(PrimitiveType.STRING))
-                                .build())
                         .build()))
-                .build();
-
-        assertThatThrownBy(() -> ConjureIrValidator.validate(definition)).isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    public void rejectsInvalidFieldNameInUnion() {
-        ConjureDefinition definition = ConjureDefinition.builder()
-                .version(1)
-                .types(List.of(TypeDefinition.union(UnionDefinition.builder()
-                        .typeName(TypeName.of("Widget", "com.example.product"))
-                        .union(FieldDefinition.builder()
-                                .fieldName(FieldName.of("not valid"))
-                                .type(Type.primitive(PrimitiveType.STRING))
-                                .build())
-                        .build())))
-                .build();
-
-        assertThatThrownBy(() -> ConjureIrValidator.validate(definition)).isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    public void acceptsValidDefinitionWithEndpointArgument() {
-        ConjureDefinition definition = ConjureDefinition.builder()
-                .version(1)
                 .services(List.of(ServiceDefinition.builder()
-                        .serviceName(TypeName.of("WidgetService", "com.example.product"))
+                        .serviceName(TypeName.of("WidgetService", PACKAGE))
                         .endpoints(EndpointDefinition.builder()
                                 .endpointName(EndpointName.of("getWidget"))
                                 .httpMethod(HttpMethod.GET)
@@ -221,12 +103,162 @@ public final class ConjureIrValidatorTest {
                 .build();
 
         assertThatCode(() -> ConjureIrValidator.validate(definition)).doesNotThrowAnyException();
+        assertThatCode(() -> ConjureIrValidator.validate(definition, SafetyDeclarationRequirements.ALLOWED))
+                .doesNotThrowAnyException();
+    }
+
+    // Type validation
+
+    @Test
+    public void rejectsInvalidPackageName() {
+        ConjureDefinition definition = ConjureDefinition.builder()
+                .version(1)
+                .types(List.of(TypeDefinition.enum_(EnumDefinition.builder()
+                        .typeName(TypeName.of("Color", "Foo"))
+                        .values(List.of(
+                                EnumValueDefinition.builder().value("RED").build()))
+                        .build())))
+                .build();
+
+        assertThatThrownBy(() -> ConjureIrValidator.validate(definition))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Conjure package names must match pattern");
     }
 
     @Test
-    public void validateWithSafetyDeclarationRequirementsDoesNotThrow() {
+    public void rejectsInvalidTypeName() {
         ConjureDefinition definition = ConjureDefinition.builder()
                 .version(1)
+                .types(List.of(TypeDefinition.enum_(EnumDefinition.builder()
+                        .typeName(TypeName.of("invalid name", PACKAGE))
+                        .values(List.of(
+                                EnumValueDefinition.builder().value("RED").build()))
+                        .build())))
+                .build();
+
+        assertThatThrownBy(() -> ConjureIrValidator.validate(definition))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("TypeNames must be a primitive type");
+    }
+
+    @Test
+    public void rejectsEnumValueOutsideGrammar() {
+        ConjureDefinition definition = ConjureDefinition.builder()
+                .version(1)
+                .types(List.of(TypeDefinition.enum_(EnumDefinition.builder()
+                        .typeName(ENUM_NAME)
+                        .values(List.of(
+                                EnumValueDefinition.builder().value("RED").build(),
+                                EnumValueDefinition.builder().value("not valid").build()))
+                        .build())))
+                .build();
+
+        assertThatThrownBy(() -> ConjureIrValidator.validate(definition))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Enumeration values must match format");
+    }
+
+    @Test
+    public void rejectsInvalidObjectFieldName() {
+        ConjureDefinition definition = ConjureDefinition.builder()
+                .version(1)
+                .types(List.of(TypeDefinition.object(ObjectDefinition.builder()
+                        .typeName(TypeName.of("Widget", PACKAGE))
+                        .fields(FieldDefinition.builder()
+                                .fieldName(FieldName.of("not valid"))
+                                .type(Type.primitive(PrimitiveType.STRING))
+                                .build())
+                        .build())))
+                .build();
+
+        assertThatThrownBy(() -> ConjureIrValidator.validate(definition))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must follow one of the following patterns");
+    }
+
+    @Test
+    public void rejectsInvalidUnionFieldName() {
+        ConjureDefinition definition = ConjureDefinition.builder()
+                .version(1)
+                .types(List.of(TypeDefinition.union(UnionDefinition.builder()
+                        .typeName(TypeName.of("Widget", PACKAGE))
+                        .union(FieldDefinition.builder()
+                                .fieldName(FieldName.of("not valid"))
+                                .type(Type.primitive(PrimitiveType.STRING))
+                                .build())
+                        .build())))
+                .build();
+
+        assertThatThrownBy(() -> ConjureIrValidator.validate(definition))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must follow one of the following patterns");
+    }
+
+    // Error validation
+
+    @Test
+    public void rejectsInvalidErrorNamespace() {
+        ConjureDefinition definition = ConjureDefinition.builder()
+                .version(1)
+                .errors(List.of(ErrorDefinition.builder()
+                        .errorName(TypeName.of("WidgetError", PACKAGE))
+                        .namespace(ErrorNamespace.of("invalidNamespace"))
+                        .code(ErrorCode.INVALID_ARGUMENT)
+                        .build()))
+                .build();
+
+        assertThatThrownBy(() -> ConjureIrValidator.validate(definition))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Namespace for errors must match pattern");
+    }
+
+    @Test
+    public void rejectsInvalidErrorFieldName() {
+        ConjureDefinition definition = ConjureDefinition.builder()
+                .version(1)
+                .errors(List.of(ErrorDefinition.builder()
+                        .errorName(TypeName.of("WidgetError", PACKAGE))
+                        .namespace(ErrorNamespace.of("Widget"))
+                        .code(ErrorCode.INVALID_ARGUMENT)
+                        .safeArgs(FieldDefinition.builder()
+                                .fieldName(FieldName.of("not valid"))
+                                .type(Type.primitive(PrimitiveType.STRING))
+                                .build())
+                        .build()))
+                .build();
+
+        assertThatThrownBy(() -> ConjureIrValidator.validate(definition))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must follow one of the following patterns");
+    }
+
+    // Service validation
+
+    @Test
+    public void rejectsInvalidHttpPath() {
+        ConjureDefinition definition = ConjureDefinition.builder()
+                .version(1)
+                .services(List.of(ServiceDefinition.builder()
+                        .serviceName(TypeName.of("WidgetService", PACKAGE))
+                        .endpoints(EndpointDefinition.builder()
+                                .endpointName(EndpointName.of("getWidget"))
+                                .httpMethod(HttpMethod.GET)
+                                .httpPath(HttpPath.of("widget"))
+                                .build())
+                        .build()))
+                .build();
+
+        assertThatThrownBy(() -> ConjureIrValidator.validate(definition))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Conjure paths must be absolute");
+    }
+
+    // ConjureDefinitionValidator.validateAll
+
+    @Test
+    public void rejectsUnsupportedVersion() {
+        ConjureDefinition definition = ConjureDefinition.builder()
+                .version(2)
                 .types(List.of(TypeDefinition.enum_(EnumDefinition.builder()
                         .typeName(ENUM_NAME)
                         .values(List.of(
@@ -234,7 +266,28 @@ public final class ConjureIrValidatorTest {
                         .build())))
                 .build();
 
-        assertThatCode(() -> ConjureIrValidator.validate(definition, SafetyDeclarationRequirements.ALLOWED))
-                .doesNotThrowAnyException();
+        assertThatThrownBy(() -> ConjureIrValidator.validate(definition))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Definition version must be");
+    }
+
+    @Test
+    public void rejectsDuplicateServiceNames() {
+        ServiceDefinition service = ServiceDefinition.builder()
+                .serviceName(TypeName.of("WidgetService", PACKAGE))
+                .endpoints(EndpointDefinition.builder()
+                        .endpointName(EndpointName.of("getWidget"))
+                        .httpMethod(HttpMethod.GET)
+                        .httpPath(HttpPath.of("/widget"))
+                        .build())
+                .build();
+        ConjureDefinition definition = ConjureDefinition.builder()
+                .version(1)
+                .services(List.of(service, service))
+                .build();
+
+        assertThatThrownBy(() -> ConjureIrValidator.validate(definition))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Service names must be unique");
     }
 }

--- a/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ConjureIrValidatorTest.java
+++ b/conjure-core/src/test/java/com/palantir/conjure/defs/validator/ConjureIrValidatorTest.java
@@ -1,0 +1,240 @@
+/*
+ * (c) Copyright 2018 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.defs.validator;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.palantir.conjure.defs.SafetyDeclarationRequirements;
+import com.palantir.conjure.spec.ArgumentDefinition;
+import com.palantir.conjure.spec.ArgumentName;
+import com.palantir.conjure.spec.ConjureDefinition;
+import com.palantir.conjure.spec.EndpointDefinition;
+import com.palantir.conjure.spec.EndpointName;
+import com.palantir.conjure.spec.EnumDefinition;
+import com.palantir.conjure.spec.EnumValueDefinition;
+import com.palantir.conjure.spec.ErrorCode;
+import com.palantir.conjure.spec.ErrorDefinition;
+import com.palantir.conjure.spec.ErrorNamespace;
+import com.palantir.conjure.spec.FieldDefinition;
+import com.palantir.conjure.spec.FieldName;
+import com.palantir.conjure.spec.HttpMethod;
+import com.palantir.conjure.spec.HttpPath;
+import com.palantir.conjure.spec.ObjectDefinition;
+import com.palantir.conjure.spec.ParameterId;
+import com.palantir.conjure.spec.ParameterType;
+import com.palantir.conjure.spec.PrimitiveType;
+import com.palantir.conjure.spec.QueryParameterType;
+import com.palantir.conjure.spec.ServiceDefinition;
+import com.palantir.conjure.spec.Type;
+import com.palantir.conjure.spec.TypeDefinition;
+import com.palantir.conjure.spec.TypeName;
+import com.palantir.conjure.spec.UnionDefinition;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public final class ConjureIrValidatorTest {
+
+    private static final TypeName ENUM_NAME = TypeName.of("Color", "com.example.product");
+
+    @Test
+    public void rejectsEnumValueOutsideGrammar() {
+        ConjureDefinition definition = ConjureDefinition.builder()
+                .version(1)
+                .types(List.of(TypeDefinition.enum_(EnumDefinition.builder()
+                        .typeName(ENUM_NAME)
+                        .values(List.of(
+                                EnumValueDefinition.builder().value("RED").build(),
+                                EnumValueDefinition.builder().value("not valid").build()))
+                        .build())))
+                .build();
+
+        assertThatThrownBy(() -> ConjureIrValidator.validate(definition)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void rejectsInvalidTypeName() {
+        ConjureDefinition definition = ConjureDefinition.builder()
+                .version(1)
+                .types(List.of(TypeDefinition.enum_(EnumDefinition.builder()
+                        .typeName(TypeName.of("invalid name", "com.example.product"))
+                        .values(List.of(
+                                EnumValueDefinition.builder().value("RED").build()))
+                        .build())))
+                .build();
+
+        assertThatThrownBy(() -> ConjureIrValidator.validate(definition)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void acceptsValidDefinition() {
+        ConjureDefinition definition = ConjureDefinition.builder()
+                .version(1)
+                .types(List.of(TypeDefinition.enum_(EnumDefinition.builder()
+                        .typeName(ENUM_NAME)
+                        .values(List.of(
+                                EnumValueDefinition.builder().value("RED").build(),
+                                EnumValueDefinition.builder().value("GREEN").build()))
+                        .build())))
+                .build();
+
+        assertThatCode(() -> ConjureIrValidator.validate(definition)).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void rejectsInvalidPackageName() {
+        ConjureDefinition definition = ConjureDefinition.builder()
+                .version(1)
+                .types(List.of(TypeDefinition.enum_(EnumDefinition.builder()
+                        .typeName(TypeName.of("Color", "Foo"))
+                        .values(List.of(
+                                EnumValueDefinition.builder().value("RED").build()))
+                        .build())))
+                .build();
+
+        assertThatThrownBy(() -> ConjureIrValidator.validate(definition)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void rejectsInvalidFieldName() {
+        ConjureDefinition definition = ConjureDefinition.builder()
+                .version(1)
+                .types(List.of(TypeDefinition.object(ObjectDefinition.builder()
+                        .typeName(TypeName.of("Widget", "com.example.product"))
+                        .fields(FieldDefinition.builder()
+                                .fieldName(FieldName.of("not valid"))
+                                .type(Type.primitive(PrimitiveType.STRING))
+                                .build())
+                        .build())))
+                .build();
+
+        assertThatThrownBy(() -> ConjureIrValidator.validate(definition)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void rejectsInvalidHttpPath() {
+        ConjureDefinition definition = ConjureDefinition.builder()
+                .version(1)
+                .services(List.of(ServiceDefinition.builder()
+                        .serviceName(TypeName.of("WidgetService", "com.example.product"))
+                        .endpoints(EndpointDefinition.builder()
+                                .endpointName(EndpointName.of("getWidget"))
+                                .httpMethod(HttpMethod.GET)
+                                .httpPath(HttpPath.of("widget"))
+                                .build())
+                        .build()))
+                .build();
+
+        assertThatThrownBy(() -> ConjureIrValidator.validate(definition)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void acceptsValidDefinitionWithObjectAndService() {
+        ConjureDefinition definition = ConjureDefinition.builder()
+                .version(1)
+                .types(List.of(TypeDefinition.object(ObjectDefinition.builder()
+                        .typeName(TypeName.of("Widget", "com.example.product"))
+                        .fields(FieldDefinition.builder()
+                                .fieldName(FieldName.of("displayName"))
+                                .type(Type.primitive(PrimitiveType.STRING))
+                                .build())
+                        .build())))
+                .services(List.of(ServiceDefinition.builder()
+                        .serviceName(TypeName.of("WidgetService", "com.example.product"))
+                        .endpoints(EndpointDefinition.builder()
+                                .endpointName(EndpointName.of("getWidget"))
+                                .httpMethod(HttpMethod.GET)
+                                .httpPath(HttpPath.of("/widget"))
+                                .build())
+                        .build()))
+                .build();
+
+        assertThatCode(() -> ConjureIrValidator.validate(definition)).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void rejectsInvalidFieldNameInError() {
+        ConjureDefinition definition = ConjureDefinition.builder()
+                .version(1)
+                .errors(List.of(ErrorDefinition.builder()
+                        .errorName(TypeName.of("WidgetError", "com.example.product"))
+                        .namespace(ErrorNamespace.of("Widget"))
+                        .code(ErrorCode.INVALID_ARGUMENT)
+                        .safeArgs(FieldDefinition.builder()
+                                .fieldName(FieldName.of("not valid"))
+                                .type(Type.primitive(PrimitiveType.STRING))
+                                .build())
+                        .build()))
+                .build();
+
+        assertThatThrownBy(() -> ConjureIrValidator.validate(definition)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void rejectsInvalidFieldNameInUnion() {
+        ConjureDefinition definition = ConjureDefinition.builder()
+                .version(1)
+                .types(List.of(TypeDefinition.union(UnionDefinition.builder()
+                        .typeName(TypeName.of("Widget", "com.example.product"))
+                        .union(FieldDefinition.builder()
+                                .fieldName(FieldName.of("not valid"))
+                                .type(Type.primitive(PrimitiveType.STRING))
+                                .build())
+                        .build())))
+                .build();
+
+        assertThatThrownBy(() -> ConjureIrValidator.validate(definition)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void acceptsValidDefinitionWithEndpointArgument() {
+        ConjureDefinition definition = ConjureDefinition.builder()
+                .version(1)
+                .services(List.of(ServiceDefinition.builder()
+                        .serviceName(TypeName.of("WidgetService", "com.example.product"))
+                        .endpoints(EndpointDefinition.builder()
+                                .endpointName(EndpointName.of("getWidget"))
+                                .httpMethod(HttpMethod.GET)
+                                .httpPath(HttpPath.of("/widget"))
+                                .args(ArgumentDefinition.builder()
+                                        .argName(ArgumentName.of("widgetId"))
+                                        .type(Type.primitive(PrimitiveType.STRING))
+                                        .paramType(
+                                                ParameterType.query(QueryParameterType.of(ParameterId.of("widgetId"))))
+                                        .build())
+                                .build())
+                        .build()))
+                .build();
+
+        assertThatCode(() -> ConjureIrValidator.validate(definition)).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void validateWithSafetyDeclarationRequirementsDoesNotThrow() {
+        ConjureDefinition definition = ConjureDefinition.builder()
+                .version(1)
+                .types(List.of(TypeDefinition.enum_(EnumDefinition.builder()
+                        .typeName(ENUM_NAME)
+                        .values(List.of(
+                                EnumValueDefinition.builder().value("RED").build()))
+                        .build())))
+                .build();
+
+        assertThatCode(() -> ConjureIrValidator.validate(definition, SafetyDeclarationRequirements.ALLOWED))
+                .doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
## Before this PR
`ConjureDefinitionValidator.validateAll` runs only cross-cutting checks (unique
names, version, recursion, nested optionals, illegal map keys, log-safety). The
per-type identifier, field, package and HTTP-path validators otherwise run only
while parsing source, so a consumer holding an already-built (e.g. deserialized)
`ConjureDefinition` has no single entry point applying the validation the compiler
applies during parse.

## After this PR
Adds `ConjureIrValidator`, which validates a fully-built `ConjureDefinition` the way
the parser does — per-type name/format validators, field name and field definition
validators, package and HTTP-path validators, endpoint validators, then the existing
cross-cutting `ConjureDefinitionValidator.validateAll`. Consumers that ingest compiled
IR can enforce the same spec conformance without re-parsing. The parser
(`ConjureParserUtils`) is unchanged.

Companion to palantir/conjure-python#1323: per review there, spec-conformance
validation of the IR belongs here, while the generator validates the code it emits.

## Possible downsides?
None expected — it composes existing validators without modifying them or the parse
path, and is purely additive (a new class).
