### PR TITLE
Accept constructs the compiler allows in conjure.schema.json

### DIFF
--- a/conjure.schema.json
+++ b/conjure.schema.json
@@ -461,20 +461,14 @@
           "$ref": "#/definitions/DocString"
         },
         "tags": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "items": {
             "type": "string"
           },
           "uniqueItems": true
         },
         "markers": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "items": {
             "$ref": "#/definitions/ConjureType"
           },
@@ -505,20 +499,14 @@
           "$ref": "#/definitions/DocString"
         },
         "tags": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "items": {
             "type": "string"
           },
           "uniqueItems": true
         },
         "markers": {
-          "type": [
-            "array",
-            "null"
-          ],
+          "type": "array",
           "items": {
             "type": "string"
           },
@@ -554,10 +542,7 @@
       ]
     },
     "DocString": {
-      "type": [
-        "string",
-        "null"
-      ]
+      "type": "string"
     },
     "LogSafety": {
       "enum": [

--- a/conjure.schema.json
+++ b/conjure.schema.json
@@ -52,6 +52,9 @@
         "external": {
           "$ref": "#/definitions/ExternalImportDefinition",
           "description": "The external types to reference."
+        },
+        "safety": {
+          "$ref": "#/definitions/LogSafety"
         }
       }
     },
@@ -128,7 +131,7 @@
     "TypeName": {
       "description": "Named types must be in PascalCase and be unique within a package.",
       "type": "string",
-      "pattern": "^([a-zA-Z]+[.])?[A-Z][a-z0-9]+([A-Z][a-z0-9]+)*$"
+      "pattern": "^([_a-zA-Z][_a-zA-Z0-9]*[.])?[A-Z][a-z0-9]+([A-Z][a-z0-9]+)*$"
     },
     "ContainerType": {
       "description": "Container types like optional<T>, list<T>, set<T> and map<K, V> can be referenced using their lowercase names, where variables like T, K and V can be substituted for a Conjure named type, a built-in or more container types:",
@@ -458,9 +461,22 @@
           "$ref": "#/definitions/DocString"
         },
         "tags": {
-          "type": "array",
+          "type": [
+            "array",
+            "null"
+          ],
           "items": {
             "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "markers": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/ConjureType"
           },
           "uniqueItems": true
         }
@@ -489,14 +505,20 @@
           "$ref": "#/definitions/DocString"
         },
         "tags": {
-          "type": "array",
+          "type": [
+            "array",
+            "null"
+          ],
           "items": {
             "type": "string"
           },
           "uniqueItems": true
         },
         "markers": {
-          "type": "array",
+          "type": [
+            "array",
+            "null"
+          ],
           "items": {
             "type": "string"
           },
@@ -532,7 +554,10 @@
       ]
     },
     "DocString": {
-      "type": "string"
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "LogSafety": {
       "enum": [

--- a/conjure/src/test/resources/json-schema/endpoint-markers.yml
+++ b/conjure/src/test/resources/json-schema/endpoint-markers.yml
@@ -1,0 +1,23 @@
+types:
+  imports:
+    EndpointMarker:
+      base-type: any
+      external:
+        java: test.api.EndpointMarker
+  definitions:
+    default-package: test.api
+    objects:
+      MarkerObject:
+        fields:
+          value: string
+services:
+  MarkerService:
+    name: Marker Service
+    package: test.api
+    base-path: /markers
+    endpoints:
+      getMarkedObject:
+        http: GET /object
+        returns: MarkerObject
+        markers:
+          - EndpointMarker

--- a/conjure/src/test/resources/json-schema/external-import-safety.yml
+++ b/conjure/src/test/resources/json-schema/external-import-safety.yml
@@ -1,0 +1,13 @@
+types:
+  imports:
+    ExternalLong:
+      base-type: string
+      external:
+        java: java.lang.Long
+      safety: safe
+  definitions:
+    default-package: test.api
+    objects:
+      ExternalSafetyObject:
+        fields:
+          longField: ExternalLong

--- a/conjure/src/test/resources/json-schema/imported-types.yml
+++ b/conjure/src/test/resources/json-schema/imported-types.yml
@@ -1,0 +1,7 @@
+types:
+  definitions:
+    default-package: test.api.imported
+    objects:
+      ImportedObject:
+        fields:
+          value: string

--- a/conjure/src/test/resources/json-schema/invalid-type-name.yml
+++ b/conjure/src/test/resources/json-schema/invalid-type-name.yml
@@ -1,0 +1,10 @@
+# Only the namespace prefix of the TypeName pattern was loosened. The PascalCase
+# portion must stay strict, because the compiler rejects consecutive capitals.
+types:
+  definitions:
+    default-package: test.api
+    objects:
+      HTTPConfig:
+        # SCHEMA(propertyNames): consecutive capitals are not PascalCase
+        fields:
+          value: string

--- a/conjure/src/test/resources/json-schema/invalid-type-reference.yml
+++ b/conjure/src/test/resources/json-schema/invalid-type-reference.yml
@@ -1,0 +1,23 @@
+# A namespace alias may contain digits, but it must still start with a letter or
+# an underscore and must not contain punctuation.
+types:
+  definitions:
+    default-package: test.api
+    objects:
+      ValidObject:
+        fields:
+          value: string
+services:
+  InvalidReferenceService:
+    name: Invalid Reference Service
+    package: test.api
+    base-path: /invalid
+    endpoints:
+      hyphenInNamespace:
+        http: GET /hyphen
+        # SCHEMA(pattern, enum): a namespace alias may not contain a hyphen
+        returns: v-5.ImportedObject
+      digitFirstNamespace:
+        http: GET /digit
+        # SCHEMA(pattern, enum): a namespace alias may not start with a digit
+        returns: 1v.ImportedObject

--- a/conjure/src/test/resources/json-schema/namespaced-type-reference.yml
+++ b/conjure/src/test/resources/json-schema/namespaced-type-reference.yml
@@ -1,0 +1,12 @@
+# The namespace alias below contains a digit. The parser's Namespace pattern and
+# the conjure-imports pattern in this schema both allow it, so a type reference
+# qualified by such a namespace must be allowed too.
+types:
+  conjure-imports:
+    v2: ./imported-types.yml
+  definitions:
+    default-package: test.api
+    objects:
+      NamespacedReference:
+        fields:
+          importedField: v2.ImportedObject

--- a/conjure/src/test/resources/json-schema/null-values.yml
+++ b/conjure/src/test/resources/json-schema/null-values.yml
@@ -1,33 +1,29 @@
 # Keys written with no value parse as null. The compiler treats these the same as
-# an absent key, so the schema must accept them.
+# an absent key, but the schema is deliberately stricter: an empty key is not
+# something an author means to keep, so editors should flag it.
 types:
   definitions:
     default-package: test.api
     objects:
       NullDocsObject:
+        # SCHEMA(type): an empty docs key is not valid
         docs:
         fields:
-          value:
-            type: string
-            docs:
+          value: string
 services:
   NullValueService:
     name: Null Value Service
     package: test.api
     base-path: /null
+    # SCHEMA(type): an empty docs key is not valid
     docs:
     endpoints:
       getValue:
         http: GET /value
         returns: NullDocsObject
+        # SCHEMA(type): an empty docs key is not valid
         docs:
+        # SCHEMA(type): an empty tags key is not valid
         tags:
+        # SCHEMA(type): an empty markers key is not valid
         markers:
-        args:
-          filter:
-            type: string
-            param-type: query
-            param-id: filter
-            docs:
-            tags:
-            markers:

--- a/conjure/src/test/resources/json-schema/null-values.yml
+++ b/conjure/src/test/resources/json-schema/null-values.yml
@@ -1,0 +1,33 @@
+# Keys written with no value parse as null. The compiler treats these the same as
+# an absent key, so the schema must accept them.
+types:
+  definitions:
+    default-package: test.api
+    objects:
+      NullDocsObject:
+        docs:
+        fields:
+          value:
+            type: string
+            docs:
+services:
+  NullValueService:
+    name: Null Value Service
+    package: test.api
+    base-path: /null
+    docs:
+    endpoints:
+      getValue:
+        http: GET /value
+        returns: NullDocsObject
+        docs:
+        tags:
+        markers:
+        args:
+          filter:
+            type: string
+            param-type: query
+            param-id: filter
+            docs:
+            tags:
+            markers:


### PR DESCRIPTION
## Before this PR

`conjure.schema.json` is published to SchemaStore and used by editors to validate Conjure definitions as
they are written. It is not read by the compiler, so it can drift from the parser without anything
failing, and it has: six constructs that `conjure compile` accepts are reported as errors, so editors
underline valid definitions.

| Construct | Why it is legal |
| --- | --- |
| namespace alias containing a digit, e.g. `v2.ImportedObject` | `Namespace` is `^[_a-zA-Z][_a-zA-Z0-9]*$`, documented at `docs/spec/conjure_definitions.md` line 58 and already used by this schema's own `conjure-imports` key pattern |
| `safety` on an external import | `ExternalTypeDefinition#safety()` is `Optional<LogSafetyDefinition>`, and the value reaches the IR as `external.safety` |
| `markers` on an endpoint | `EndpointDefinition#markers()` is `Set<ConjureType>` |
| `docs:` with no value | `Optional<String> docs()`, so `null` is an absent key |
| `tags:` with no value | `Set<String> tags()` |
| argument `markers:` with no value | `Set<ConjureType> markers()` |

The last three are what you get when a key is typed ahead of its value, a normal intermediate state while
editing.

The fixtures added here are the reproductions: each fails against the current schema and compiles cleanly
with `conjure compile`.

## After this PR

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Allow the JSON schema to accept six constructs the Conjure compiler already accepts: namespaced type
references whose namespace contains a digit or underscore, `safety` on an external import, `markers` on
an endpoint, and `docs`/`tags`/`markers` keys written with no value.
==COMMIT_MSG==

| Node | Change |
| --- | --- |
| `TypeName.pattern` | namespace prefix `([a-zA-Z]+[.])?` to `([_a-zA-Z][_a-zA-Z0-9]*[.])?` |
| `ExternalTypeDefinition` | add `safety: {$ref: LogSafety}` |
| `EndpointDefinition` | add `markers`, items `ConjureType`, nullable |
| `EndpointDefinition.tags` | `type: array` to `type: [array, null]` |
| `ArgumentDefinition.tags`, `ArgumentDefinition.markers` | `type: array` to `type: [array, null]` |
| `DocString` | `type: string` to `type: [string, null]` |

The PascalCase portion of `TypeName` is untouched, so `HTTPConfig` is still rejected, matching
`TypeName`'s own `^[A-Z][a-z0-9]+([A-Z][a-z0-9]+)*$`.

Seven fixtures are added under `conjure/src/test/resources/json-schema/`, picked up by the recursive
`Files.walk` in `ConjureJsonSchemaTest`. Two are negative fixtures asserting the loosened patterns did not
go too far: `HTTPConfig` is still rejected as a type name, and `v-5.Foo` and `1v.Foo` are still rejected
as type references.

## Possible downsides?

The schema is not an input to the compiler, so this cannot change the outcome of a build. The only risk is
a schema that accepts something it should reject, and both loosened patterns are bounded by the negative
fixtures above.

Two things worth flagging rather than leaving to be found:

1. **Endpoint `markers` is supported by the parser but is not in the spec.** The `EndpointDefinition`
   table in `docs/spec/conjure_definitions.md` lists `http`, `auth`, `returns`, `errors`, `args`, `docs`,
   `deprecated` and `tags`, but not `markers`, even though `EndpointDefinition#markers()` exists and the
   value reaches the IR. This PR follows the parser. Happy to send a follow-up adding the row if you would
   rather the spec led.

2. **`safety` on an external import has the same gap.** The `ExternalTypeDefinition` table lists only
   `base-type` and `external`. Same offer.
